### PR TITLE
Add support for ALTER TABLE foo RENAME COLUMN

### DIFF
--- a/core/src/main/grammars/sqlite.bnf
+++ b/core/src/main/grammars/sqlite.bnf
@@ -61,9 +61,10 @@ sql_stmt ::= [ EXPLAIN [ QUERY PLAN ] ] ( alter_table_stmt | analyze_stmt | atta
   pin = 2
 }
 private sql_stmt_recovery ::= !( ';' | ALTER | ANALYZE | ATTACH | BEGIN | COMMIT | END | ROLLBACK | SAVEPOINT | RELEASE | CREATE | DROP | INSERT | WITH | UPDATE | DELETE | SELECT | PRAGMA | REINDEX )
-alter_table_stmt ::= ALTER TABLE [ database_name '.' ] table_name ( RENAME TO new_table_name | ADD [ COLUMN ] column_def ) {
+alter_table_stmt ::= ALTER TABLE [ database_name '.' ] table_name ( RENAME TO new_table_name | ADD [ COLUMN ] column_def | alter_table_rename_column_clause ) {
   pin = 1
 }
+alter_table_rename_column_clause ::= RENAME [ COLUMN ] column_name TO column_name
 analyze_stmt ::= ANALYZE [ database_name | table_or_index_name | database_name '.' table_or_index_name ] {
   pin = 1
 }

--- a/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/SqliteColumnReference.kt
+++ b/core/src/main/kotlin/com/alecstrong/sqlite/psi/core/psi/SqliteColumnReference.kt
@@ -28,7 +28,9 @@ internal class SqliteColumnReference<T: SqliteNamedElementImpl>(
   override fun resolve() = resolved
 
   internal fun resolveToQuery(): QueryColumn? {
-    if (element.parent is SqliteColumnDef || element.parent is CreateVirtualTableMixin) return null
+    // This element is part of a DDL statement that itself brings the column into scope.
+    // There is no query to refer to, so we can only return null here.
+    if (element.parent is SqliteColumnDef || element.parent is CreateVirtualTableMixin || element.parent is SqliteAlterTableRenameColumnClause) return null
 
     val tableName = tableName()
     val tables: List<QueryResult>
@@ -45,7 +47,8 @@ internal class SqliteColumnReference<T: SqliteNamedElementImpl>(
   }
 
   internal fun unsafeResolve(): PsiElement? {
-    if (element.parent is SqliteColumnDef || element.parent is CreateVirtualTableMixin) return element
+    // This element is part of a DDL statement, so itself defines this column
+    if (element.parent is SqliteColumnDef || element.parent is CreateVirtualTableMixin || element.parent is SqliteAlterTableRenameColumnClause) return element
 
     val tableName = tableName()
     val tables: List<QueryResult>

--- a/core/src/test/fixtures/alter-table/Test.s
+++ b/core/src/test/fixtures/alter-table/Test.s
@@ -1,0 +1,8 @@
+CREATE TABLE user(
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+ALTER TABLE user RENAME COLUMN id TO user_id;
+
+ALTER TABLE user RENAME user_id TO id;


### PR DESCRIPTION
Fixes https://github.com/cashapp/sqldelight/issues/1505

This code doesn't currently verify that the column name we're renaming from actually exists, but to me that sounds like a non-trivial amount of work, as it would need to know what the db schema looks like at that exact point in the migration. 

Instead I've just made it so the column reference regards the column name element as defining itself, as a cheap and quick workaround to avoid the error `"No column found with name $name"` from `ColumnNameMixin`.

Am I right in thinking this is fine and the intended workflow is to rely on the VerifyMigration task for this purpose?
