### PR TITLE
Support remaining integer types in MySQL

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/mysql/MySql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/mysql/MySql.bnf
@@ -8,7 +8,12 @@
   psiClassPrefix = "MySql"
 }
 type_name ::= (
-  exact_numeric_data_type |
+  tiny_int_data_type |
+  small_int_data_type |
+  medium_int_data_type |
+  int_data_type |
+  big_int_data_type |
+  fixed_point_data_type |
   approximate_numeric_data_type |
   date_data_type |
   string_data_type |
@@ -20,7 +25,13 @@ type_name ::= (
   override = true
 }
 
-exact_numeric_data_type ::= 'INTEGER' | 'INT' | 'SMALLINT' | 'DECIMAL' | 'DEC' | 'FIXED' | 'NUMERIC'
+tiny_int_data_type ::= 'TINYINT'
+small_int_data_type ::= 'SMALLINT'
+medium_int_data_type ::= 'MEDIUMINT'
+int_data_type ::= 'INTEGER' | 'INT'
+big_int_data_type ::= 'BIGINT'
+
+fixed_point_data_type ::= 'DECIMAL' | 'DEC' | 'FIXED' | 'NUMERIC'
 
 approximate_numeric_data_type ::= 'FLOAT' | 'REAL' | ( 'DOUBLE' 'PRECISION' ) | 'DOUBLE'
 

--- a/core/src/test/fixtures_mysql/column_types/Sample.s
+++ b/core/src/test/fixtures_mysql/column_types/Sample.s
@@ -1,7 +1,10 @@
 CREATE TABLE all_types(
+  some_tiny_int TINYINT,
+  some_small_int SMALLINT,
+  some_medium_int MEDIUMINT,
   some_integer INTEGER,
   some_int INT,
-  same_small_int SMALLINT,
+  some_big_int BIGINT,
   some_decimal DECIMAL,
   some_dec DEC,
   some_fixed FIXED,


### PR DESCRIPTION
Extension of the MySQL grammar to support https://github.com/cashapp/sqldelight/issues/1675.