### PR TITLE
Synthesized columns should retain nullability across joins

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/SqlColumnReference.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/SqlColumnReference.kt
@@ -39,9 +39,13 @@ internal class SqlColumnReference<T : SqlNamedElementImpl>(
       tables = availableQuery().filterNot { it.table is SingleRow }
     }
 
-    return tables.flatMap { it.columns }
+    val columns = tables.flatMap { it.columns }
         .filter { it.element is PsiNamedElement && it.element.name == element.name }
-        .firstOrNull()
+    val synthesizedColumns = tables.flatMap { it.synthesizedColumns }
+        .filter { element.name in it.acceptableValues }
+        .map { QueryColumn(it.table, it.nullable) }
+
+    return (columns + synthesizedColumns).firstOrNull()
   }
 
   internal fun unsafeResolve(): PsiElement? {

--- a/core/src/test/kotlin/com/alecstrong/sql/psi/core/NullabilityTest.kt
+++ b/core/src/test/kotlin/com/alecstrong/sql/psi/core/NullabilityTest.kt
@@ -22,7 +22,7 @@ class NullabilityTest {
       |);
       |
       |SELECT *
-      |FROM (SELECT owner.name, car.brand AS carBrand
+      |FROM (SELECT owner.name, car.brand AS carBrand, car.rowid AS rowid
       |      FROM owner
       |      LEFT OUTER JOIN car ON owner.carId = car.id)
       |WHERE carBrand = ?;
@@ -33,6 +33,7 @@ class NullabilityTest {
 
     assertThat(projection[0].nullable).isFalse()
     assertThat(projection[1].nullable).isTrue()
+    assertThat(projection[2].nullable).isTrue()
   }
 
   private fun compileFile(text: String): SqlFileBase {


### PR DESCRIPTION
closes https://github.com/cashapp/sqldelight/issues/1656