### PR TITLE
Specify PostgreSQL type modifiers on a per type basis

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/PostgreSql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/PostgreSql.bnf
@@ -17,7 +17,7 @@ type_name ::= (
   string_data_type |
   date_data_type |
   json_data_type
-) [ '(' {signed_number} ')' | '(' {signed_number} ',' {signed_number} ')' ] {
+) {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlTypeNameImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlTypeName"
   override = true
@@ -31,12 +31,12 @@ bind_parameter ::= ( '?' | ':' {identifier} ) {
 small_int_data_type ::= 'SMALLINT' | 'INT2'
 int_data_type ::= 'INTEGER' | 'INT' | 'INT4'
 big_int_data_type ::= 'BIGINT' | 'INT8'
-numeric_data_type ::= 'NUMERIC' | 'DECIMAL'
+numeric_data_type ::= ('NUMERIC' | 'DECIMAL') [ '(' {signed_number} ')' | '(' {signed_number} ',' {signed_number} ')' ]
 
-approximate_numeric_data_type ::= 'REAL' | 'FLOAT4' | ( 'DOUBLE' 'PRECISION' ) | 'FLOAT8'
+approximate_numeric_data_type ::= ('REAL' | 'FLOAT4' | ( 'DOUBLE' 'PRECISION' ) | 'FLOAT8') | ('FLOAT' [ '(' {signed_number} ')' ])
 
-string_data_type ::= ( 'CHARACTER' 'VARYING' ) | 'VARCHAR' | 'CHARACTER' | 'CHAR' | 'TEXT'
+string_data_type ::= ((( 'CHARACTER' 'VARYING' ) | 'VARCHAR' | 'CHARACTER' | 'CHAR') [ '(' {signed_number} ')' ]) | 'TEXT'
 
-date_data_type ::= 'DATE' | 'TIME' | 'TIMESTAMP'
+date_data_type ::= 'DATE' | (('TIME' | 'TIMESTAMP') [ '(' {signed_number} ')' ])
 
 json_data_type ::= 'JSON'


### PR DESCRIPTION
In the original implementation, it is specified that every type can optionally take one or two type arguments, each of which are signed numbers. However, according to the [documentation](https://www.postgresql.org/docs/12/datatype.html), some types can optionally take one type argument, while some disallow type modifiers altogether.