### PR TITLE
Allow optional column type in virtual table modules to support FTS5

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateVirtualTableMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateVirtualTableMixin.kt
@@ -20,7 +20,7 @@ internal abstract class CreateVirtualTableMixin(
   override fun tableExposed(): LazyQuery {
     val columnNameElements = findChildrenByClass(
         SqlModuleArgument::class.java)
-        .mapNotNull { it.moduleArgumentDef?.moduleColumnDef?.columnName }
+        .mapNotNull { it.moduleArgumentDef?.moduleColumnDef?.columnName ?: it.moduleArgumentDef?.columnDef?.columnName }
 
     val synthesizedColumns = if (usesFtsModule) {
       val columnNames = columnNameElements.map { it.name }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateVirtualTableMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateVirtualTableMixin.kt
@@ -20,7 +20,7 @@ internal abstract class CreateVirtualTableMixin(
   override fun tableExposed(): LazyQuery {
     val columnNameElements = findChildrenByClass(
         SqlModuleArgument::class.java)
-        .mapNotNull { it.columnDef?.columnName }
+        .mapNotNull { it.moduleArgumentDef?.moduleColumnDef?.columnName }
 
     val synthesizedColumns = if (usesFtsModule) {
       val columnNames = columnNameElements.map { it.name }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/ModuleColumnDefMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/ModuleColumnDefMixin.kt
@@ -1,0 +1,12 @@
+package com.alecstrong.sql.psi.core.psi.mixins
+
+import com.alecstrong.sql.psi.core.psi.SqlColumnDef
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.alecstrong.sql.psi.core.psi.SqlModuleColumnDef
+import com.intellij.lang.ASTNode
+
+// Throws if you access typeName and one doesn't
+// exist — typeName is optional for ModuleColumnDef
+internal abstract class ModuleColumnDefMixin(
+  node: ASTNode
+) : SqlCompositeElementImpl(node), SqlModuleColumnDef, SqlColumnDef

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -120,7 +120,7 @@ module_column_def ::= column_name [ type_name ] ( column_constraint ) * {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.ModuleColumnDefMixin"
   implements = "com.alecstrong.sql.psi.core.psi.SqlColumnDef"
 }
-module_argument_def ::= ( module_argument_name '=' (string_literal | identifier) ) | module_column_def
+module_argument_def ::= ( module_argument_name '=' (string_literal | identifier) ) | column_def | module_column_def
 create_virtual_table_stmt ::= CREATE VIRTUAL TABLE [ IF NOT EXISTS ] [ database_name '.' ] table_name USING module_name [ '(' <<custom_module_argument module_argument_def>> ( ',' <<custom_module_argument module_argument_def>> ) * ')' ] {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.CreateVirtualTableMixin"
   implements = "com.alecstrong.sql.psi.core.psi.TableElement"

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -119,7 +119,6 @@ create_view_stmt ::= CREATE [ TEMP | TEMPORARY ] VIEW [ IF NOT EXISTS ] [ databa
 module_column_def ::= column_name [ type_name ] ( column_constraint ) * {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.ModuleColumnDefMixin"
   implements = "com.alecstrong.sql.psi.core.psi.SqlColumnDef"
-  pin = 6
 }
 module_argument_def ::= ( module_argument_name '=' (string_literal | identifier) ) | module_column_def
 create_virtual_table_stmt ::= CREATE VIRTUAL TABLE [ IF NOT EXISTS ] [ database_name '.' ] table_name USING module_name [ '(' <<custom_module_argument module_argument_def>> ( ',' <<custom_module_argument module_argument_def>> ) * ')' ] {

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -116,12 +116,18 @@ create_view_stmt ::= CREATE [ TEMP | TEMPORARY ] VIEW [ IF NOT EXISTS ] [ databa
   implements = "com.alecstrong.sql.psi.core.psi.TableElement"
   pin = 6
 }
-create_virtual_table_stmt ::= CREATE VIRTUAL TABLE [ IF NOT EXISTS ] [ database_name '.' ] table_name USING module_name [ '(' <<custom_module_argument column_def>> ( ',' <<custom_module_argument column_def>> ) * ')' ] {
+module_column_def ::= column_name [ type_name ] ( column_constraint ) * {
+  mixin = "com.alecstrong.sql.psi.core.psi.mixins.ModuleColumnDefMixin"
+  implements = "com.alecstrong.sql.psi.core.psi.SqlColumnDef"
+  pin = 6
+}
+module_argument_def ::= ( module_argument_name '=' (string_literal | identifier) ) | module_column_def
+create_virtual_table_stmt ::= CREATE VIRTUAL TABLE [ IF NOT EXISTS ] [ database_name '.' ] table_name USING module_name [ '(' <<custom_module_argument module_argument_def>> ( ',' <<custom_module_argument module_argument_def>> ) * ')' ] {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.CreateVirtualTableMixin"
   implements = "com.alecstrong.sql.psi.core.psi.TableElement"
   pin = 6
 }
-module_argument ::= [ column_def ]
+module_argument ::= [ module_argument_def ]
 with_clause ::= WITH [ RECURSIVE ] cte_table_name AS '(' compound_select_stmt ')' ( ',' cte_table_name AS '(' compound_select_stmt ')' ) * {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.WithClauseMixin"
   pin = 1
@@ -386,6 +392,7 @@ view_name ::= id {
   ]
 }
 module_name ::= id
+module_argument_name ::= id
 bind_parameter ::= '?'
 table_options ::= table_option ( [','] table_option ) *
 table_option ::= WITHOUT ROWID

--- a/core/src/test/fixtures/fts5-tables/Test.s
+++ b/core/src/test/fixtures/fts5-tables/Test.s
@@ -1,0 +1,15 @@
+CREATE VIRTUAL TABLE data5 USING fts5(text, content=other_table, content_rowid=rowid, prefix='2 3 4 5 6');
+
+SELECT *
+FROM data5
+WHERE text MATCH 'fts5';
+
+SELECT text
+FROM data5
+WHERE text MATCH 'fts5';
+
+INSERT INTO data5(text)
+VALUES (?);
+
+INSERT INTO data5
+VALUES (?);


### PR DESCRIPTION
First step to closing cashapp/sqldelight#1622