### PR TITLE
Tests for #88

### DIFF
--- a/core/src/test/fixtures_hsql/column_types/Sample.s
+++ b/core/src/test/fixtures_hsql/column_types/Sample.s
@@ -14,6 +14,8 @@ CREATE TABLE all_types(
   some_boolean BOOLEAN,
   some_date DATE,
   some_time TIME,
+  some_time2 TIME(6) WITH TIME ZONE,
+  some_timestamp TIMESTAMP WITHOUT TIME ZONE,
   some_timestamp2 TIMESTAMP(6),
   some_char CHAR,
   some_character CHARACTER(6),


### PR DESCRIPTION
@AlecStrong I mentioned during the initial HSQL support commit that specifying timezones was not working. The following are the tests that demonstrate this. In [the BNF](https://github.com/AlecStrong/sql-psi/blob/master/core/src/main/kotlin/com/alecstrong/sql/psi/core/hsql/hsql.bnf#L58) I took a stab at supporting these, but fell short. 