### PR TITLE
Give better error for missing table/column when creating an index

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateIndexMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateIndexMixin.kt
@@ -13,7 +13,9 @@ internal abstract class CreateIndexMixin(
     SqlCreateIndexStmt {
   override fun queryAvailable(child: PsiElement): Collection<QueryResult> {
     if (child in indexedColumnList || child == expr) {
-      return listOf(tablesAvailable(child).first { it.tableName.name == tableName?.name }.query)
+      return listOfNotNull(
+          tablesAvailable(child).firstOrNull { it.tableName.name == tableName?.name }?.query
+      )
     }
     return super.queryAvailable(child)
   }

--- a/core/src/test/fixtures/index-on-bad-table/Test.s
+++ b/core/src/test/fixtures/index-on-bad-table/Test.s
@@ -1,0 +1,5 @@
+-- error[col 48]: No table found with name Channel
+CREATE UNIQUE INDEX idx_channel_original_url ON Channel(
+-- error[col 2]: No column found with name originalUrl
+  originalUrl
+);


### PR DESCRIPTION
Closes https://github.com/cashapp/sqldelight/issues/1372