### PR TITLE
Fix compiler warning about unused variable

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/DialectPresets.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/DialectPresets.kt
@@ -8,40 +8,48 @@ import com.alecstrong.sql.psi.core.sqlite_3_24.SqliteParserUtil as Sqlite_3_24Ut
 import com.alecstrong.sql.psi.core.sqlite_3_25.SqliteParserUtil as Sqlite_3_25Util
 
 enum class DialectPreset {
-  SQLITE_3_18, SQLITE_3_24, SQLITE_3_25, MYSQL, POSTGRESQL, HSQL;
-
-  fun setup() {
-    val exhaustive = when (this) {
-      SQLITE_3_18 -> {
-        SqlParserUtil.reset()
-        Sqlite_3_18Util.reset()
-        Sqlite_3_18Util.overrideSqlParser()
-      }
-      SQLITE_3_24 -> {
-        SQLITE_3_18.setup()
-        Sqlite_3_24Util.reset()
-        Sqlite_3_24Util.overrideSqlParser()
-      }
-      SQLITE_3_25 -> {
-        SQLITE_3_24.setup()
-        Sqlite_3_25Util.reset()
-        Sqlite_3_25Util.overrideSqlParser()
-      }
-      MYSQL -> {
-        SqlParserUtil.reset()
-        MySqlParserUtil.reset()
-        MySqlParserUtil.overrideSqlParser()
-      }
-      HSQL -> {
-        SqlParserUtil.reset()
-        HsqlParserUtil.reset()
-        HsqlParserUtil.overrideSqlParser()
-      }
-      POSTGRESQL -> {
-        SqlParserUtil.reset()
-        PostgreSqlParserUtil.reset()
-        PostgreSqlParserUtil.overrideSqlParser()
-      }
+  SQLITE_3_18 {
+    override fun setup() {
+      SqlParserUtil.reset()
+      Sqlite_3_18Util.reset()
+      Sqlite_3_18Util.overrideSqlParser()
     }
-  }
+  },
+  SQLITE_3_24 {
+    override fun setup() {
+      SQLITE_3_18.setup()
+      Sqlite_3_24Util.reset()
+      Sqlite_3_24Util.overrideSqlParser()
+    }
+  },
+  SQLITE_3_25 {
+    override fun setup() {
+      SQLITE_3_24.setup()
+      Sqlite_3_25Util.reset()
+      Sqlite_3_25Util.overrideSqlParser()
+    }
+  },
+  MYSQL {
+    override fun setup() {
+      SqlParserUtil.reset()
+      MySqlParserUtil.reset()
+      MySqlParserUtil.overrideSqlParser()
+    }
+  },
+  POSTGRESQL {
+    override fun setup() {
+      SqlParserUtil.reset()
+      PostgreSqlParserUtil.reset()
+      PostgreSqlParserUtil.overrideSqlParser()
+    }
+  },
+  HSQL {
+    override fun setup() {
+      SqlParserUtil.reset()
+      HsqlParserUtil.reset()
+      HsqlParserUtil.overrideSqlParser()
+    }
+  };
+
+  abstract fun setup()
 }


### PR DESCRIPTION
Fixes the compiler warning: `Variable 'exhaustive' is never used`. The fix is a bit more verbose than the previous implementation, but the logic to call `setup()` of the respective `DialectPreset.*` is now more to the point.