### PR TITLE
Support SERIAL NOT NULL as default value in PostgreSQL

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/columnDef.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/columnDef.kt
@@ -1,8 +1,6 @@
 package com.alecstrong.sql.psi.core
 
-import com.alecstrong.sql.psi.core.postgresql.psi.PostgreSqlBigSerialDataType
-import com.alecstrong.sql.psi.core.postgresql.psi.PostgreSqlSerialDataType
-import com.alecstrong.sql.psi.core.postgresql.psi.PostgreSqlSmallSerialDataType
+import com.alecstrong.sql.psi.core.postgresql.psi.PostgreSqlTypeName
 import com.alecstrong.sql.psi.core.psi.SqlColumnDef
 import com.alecstrong.sql.psi.core.psi.SqlTypes
 
@@ -24,7 +22,6 @@ fun SqlColumnDef.hasDefaultValue(): Boolean {
 }
 
 private fun SqlColumnDef.isSerial(): Boolean {
-  return (this.typeName is PostgreSqlSmallSerialDataType ||
-    this.typeName is PostgreSqlSerialDataType ||
-    this.typeName is PostgreSqlBigSerialDataType)
+  val typeName = typeName as? PostgreSqlTypeName ?: return false
+  return typeName.smallSerialDataType != null || typeName.serialDataType != null || typeName.bigSerialDataType != null
 }

--- a/core/src/test/fixtures_postgresql/serial/ExplicitNotNull.s
+++ b/core/src/test/fixtures_postgresql/serial/ExplicitNotNull.s
@@ -1,0 +1,23 @@
+CREATE TABLE test0(
+    id SERIAL NOT NULL,
+    words TEXT NOT NULL
+);
+
+INSERT INTO test0(words)
+VALUES ("foo");
+
+CREATE TABLE test1(
+    id SMALLSERIAL NOT NULL,
+    words TEXT NOT NULL
+);
+
+INSERT INTO test1(words)
+VALUES ("foo");
+
+CREATE TABLE test2(
+    id BIGSERIAL NOT NULL,
+    words TEXT NOT NULL
+);
+
+INSERT INTO test2(words)
+VALUES ("foo");

--- a/core/src/test/fixtures_postgresql/serial/ImplicitNotNull.s
+++ b/core/src/test/fixtures_postgresql/serial/ImplicitNotNull.s
@@ -1,0 +1,23 @@
+CREATE TABLE test3(
+    id SERIAL,
+    words TEXT NOT NULL
+);
+
+INSERT INTO test3(words)
+VALUES ("foo");
+
+CREATE TABLE test4(
+    id SMALLSERIAL,
+    words TEXT NOT NULL
+);
+
+INSERT INTO test4(words)
+VALUES ("foo");
+
+CREATE TABLE test5(
+    id BIGSERIAL,
+    words TEXT NOT NULL
+);
+
+INSERT INTO test5(words)
+VALUES ("foo");


### PR DESCRIPTION
Resolves #150 (hopefully for the last time 💀).

The tests are a bit verbose, so lmk if there is any way to make it a bit more succinct.