### PR TITLE
Remove reference to PostgreSQL in ResultColumnMixin

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/psi/mixins/ReturningClauseMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/psi/mixins/ReturningClauseMixin.kt
@@ -2,13 +2,15 @@ package com.alecstrong.sql.psi.core.postgresql.psi.mixins
 
 import com.alecstrong.sql.psi.core.ModifiableFileLazy
 import com.alecstrong.sql.psi.core.postgresql.psi.PostgreSqlReturningClause
+import com.alecstrong.sql.psi.core.psi.FromQuery
 import com.alecstrong.sql.psi.core.psi.QueryElement.QueryResult
 import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
 import com.alecstrong.sql.psi.core.psi.SqlResultColumn
 import com.intellij.lang.ASTNode
 import com.intellij.psi.util.PsiTreeUtil
 
-internal abstract class ReturningClauseMixin(node: ASTNode) : SqlCompositeElementImpl(node), PostgreSqlReturningClause {
+internal abstract class ReturningClauseMixin(node: ASTNode) :
+  SqlCompositeElementImpl(node), PostgreSqlReturningClause, FromQuery {
 
   private val queryExposed: Collection<QueryResult> by ModifiableFileLazy(containingFile) {
     listOf(
@@ -21,4 +23,6 @@ internal abstract class ReturningClauseMixin(node: ASTNode) : SqlCompositeElemen
   }
 
   override fun queryExposed() = queryExposed
+
+  override fun fromQuery(): Collection<QueryResult> = emptyList()
 }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/FromQuery.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/FromQuery.kt
@@ -1,0 +1,6 @@
+package com.alecstrong.sql.psi.core.psi
+
+internal interface FromQuery {
+
+  fun fromQuery(): Collection<QueryElement.QueryResult>
+}

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/ResultColumnMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/ResultColumnMixin.kt
@@ -1,7 +1,7 @@
 package com.alecstrong.sql.psi.core.psi.mixins
 
 import com.alecstrong.sql.psi.core.ModifiableFileLazy
-import com.alecstrong.sql.psi.core.postgresql.psi.PostgreSqlReturningClause
+import com.alecstrong.sql.psi.core.psi.FromQuery
 import com.alecstrong.sql.psi.core.psi.QueryElement
 import com.alecstrong.sql.psi.core.psi.QueryElement.QueryResult
 import com.alecstrong.sql.psi.core.psi.SqlColumnExpr
@@ -14,11 +14,7 @@ internal abstract class ResultColumnMixin(
 ) : SqlCompositeElementImpl(node),
     SqlResultColumn {
   private val queryExposed: Collection<QueryResult> by ModifiableFileLazy(containingFile) lazy@{
-    val fromQuery = when (val parent = parent) {
-      is SelectStmtMixin -> parent.fromQuery()
-      is PostgreSqlReturningClause -> emptyList()
-      else -> return@lazy emptyList<QueryResult>()
-    }
+    val fromQuery = (parent as? FromQuery)?.fromQuery() ?: return@lazy emptyList<QueryResult>()
     tableName?.let { tableNameElement ->
       // table_name '.' '*'
       return@lazy fromQuery.filter { it.table?.name == tableNameElement.name }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/SelectStmtMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/SelectStmtMixin.kt
@@ -2,6 +2,7 @@ package com.alecstrong.sql.psi.core.psi.mixins
 
 import com.alecstrong.sql.psi.core.ModifiableFileLazy
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.FromQuery
 import com.alecstrong.sql.psi.core.psi.QueryElement.QueryResult
 import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
 import com.alecstrong.sql.psi.core.psi.SqlSelectStmt
@@ -12,7 +13,8 @@ import com.intellij.psi.PsiElement
 internal abstract class SelectStmtMixin(
   node: ASTNode
 ) : SqlCompositeElementImpl(node),
-    SqlSelectStmt {
+    SqlSelectStmt,
+    FromQuery {
   private val queryExposed: Collection<QueryResult> by ModifiableFileLazy(containingFile) {
     if (valuesExpressionList.isNotEmpty()) {
       return@ModifiableFileLazy listOf(QueryResult(null, valuesExpressionList.first().exprList.asColumns()))
@@ -34,7 +36,7 @@ internal abstract class SelectStmtMixin(
 
   override fun queryExposed() = queryExposed
 
-  internal fun fromQuery(): Collection<QueryResult> {
+  override fun fromQuery(): Collection<QueryResult> {
     joinClause?.let {
       return it.queryExposed()
     }


### PR DESCRIPTION
Addresses https://github.com/AlecStrong/sql-psi/pull/170#discussion_r484070017 without fully addressing https://github.com/AlecStrong/sql-psi/issues/173. I've just been playing around with how to do the dialect module split and the reference to PostgreSQL in this mixin is a hindrance.