### PR TITLE
Simplify PostgreSQL's ColumnDefMixin

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/psi/mixins/ColumnDefMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/psi/mixins/ColumnDefMixin.kt
@@ -8,7 +8,7 @@ import com.intellij.lang.ASTNode
 internal class ColumnDefMixin(node: ASTNode) : SqlColumnDefImpl(node), SqlColumnDef {
 
   override fun hasDefaultValue(): Boolean {
-    return columnConstraintList.any { isSerial() } || super.hasDefaultValue()
+    return isSerial() || super.hasDefaultValue()
   }
 }
 


### PR DESCRIPTION
There's no need to iterate through each element in `columnConstraintList` in `columnConstraintList.any { isSerial() }` as `isSerial()` ignores each element of the list.