### PR TITLE
Rejig the column def rule for better extensibility

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/psi/mixins/ColumnDefMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/psi/mixins/ColumnDefMixin.kt
@@ -13,6 +13,6 @@ internal class ColumnDefMixin(node: ASTNode) : SqlColumnDefImpl(node), SqlColumn
 }
 
 private fun SqlColumnDef.isSerial(): Boolean {
-  val typeName = typeName as PostgreSqlTypeName
+  val typeName = columnType.typeName as PostgreSqlTypeName
   return typeName.smallSerialDataType != null || typeName.serialDataType != null || typeName.bigSerialDataType != null
 }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/ColumnDefMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/ColumnDefMixin.kt
@@ -5,7 +5,7 @@ import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
 import com.alecstrong.sql.psi.core.psi.SqlTypes
 import com.intellij.lang.ASTNode
 
-internal abstract class ColumnDefMixin(node: ASTNode) : SqlCompositeElementImpl(node), SqlColumnDef {
+abstract class ColumnDefMixin(node: ASTNode) : SqlCompositeElementImpl(node), SqlColumnDef {
 
   open fun hasDefaultValue(): Boolean {
     return columnConstraintList.any { it.defaultConstraint != null } ||

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -101,9 +101,10 @@ create_table_stmt ::= CREATE [ TEMP | TEMPORARY ] TABLE [ IF NOT EXISTS ] [ data
   implements = "com.alecstrong.sql.psi.core.psi.TableElement"
   pin = 6
 }
-column_def ::= [ javadoc ] column_name type_name ( column_constraint ) * {
+column_def ::= [ javadoc ] column_name column_type ( column_constraint ) * {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.ColumnDefMixin"
 }
+column_type ::= type_name
 type_name ::= identifier [ '(' signed_number ')' | '(' signed_number ',' signed_number ')' ]
 column_constraint ::= [ CONSTRAINT identifier ] ( PRIMARY KEY [ ASC | DESC ] conflict_clause [ AUTOINCREMENT ] | NOT NULL conflict_clause | UNIQUE conflict_clause | check_constraint | default_constraint | COLLATE collation_name | foreign_key_clause )
 check_constraint ::= CHECK '(' expr ')'
@@ -123,7 +124,7 @@ create_view_stmt ::= CREATE [ TEMP | TEMPORARY ] VIEW [ IF NOT EXISTS ] [ databa
   implements = "com.alecstrong.sql.psi.core.psi.TableElement"
   pin = 6
 }
-module_column_def ::= [ javadoc ] column_name [ type_name ] ( column_constraint ) * {
+module_column_def ::= [ javadoc ] column_name [ column_type ] ( column_constraint ) * {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.ModuleColumnDefMixin"
   implements = "com.alecstrong.sql.psi.core.psi.SqlColumnDef"
 }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_18/psi/mixins/ColumnDefMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_18/psi/mixins/ColumnDefMixin.kt
@@ -13,7 +13,7 @@ internal class ColumnDefMixin(node: ASTNode) : SqlColumnDefImpl(node) {
       // https://www.sqlite.org/autoinc.html
       // "On an INSERT, if the ROWID or INTEGER PRIMARY KEY column is not explicitly given a value, then it will be
       // filled automatically with an unused integer .. regardless of whether or not the AUTOINCREMENT keyword is used."
-      this.typeName.text == "INTEGER" &&
+      columnType.typeName.text == "INTEGER" &&
         this.columnConstraintList.any { it.node.findChildByType(SqlTypes.PRIMARY) != null }
       ) ||
       super.hasDefaultValue()


### PR DESCRIPTION
So I think I like this more than the column-constraint idea to fix the columnDefMixin issue I described yesterday, since this also enables domains in the way you were describing:

```
CREATE DOMAIN http_url TEXT AS OkHttp.Url CHECK (...)
```

sqldelight override the column_type rule instead of column_def, so the setup in sql-psi works now, and this lets column_def get used elsewhere (like in domains). 

see this branch for the sqldelight side: https://github.com/cashapp/sqldelight/pull/1955