### PR TITLE
Separate SQLite data types into separate rules

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_18/sqlite.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_18/sqlite.bnf
@@ -14,11 +14,16 @@
 }
 overrides ::= type_name | bind_parameter | alter_table_stmt
 
-type_name ::= 'TEXT' | 'BLOB' | 'INTEGER' | 'REAL' {
+type_name ::= text_data_type | blob_data_type | int_data_type | real_data_type {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlTypeNameImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlTypeName"
   override = true
 }
+text_data_type ::= 'TEXT'
+blob_data_type ::= 'BLOB'
+int_data_type ::= 'INTEGER'
+real_data_type ::= 'REAL'
+
 bind_parameter ::= ( '?' [digit] | ':' {identifier} ) {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlBindParameterImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlBindParameter"


### PR DESCRIPTION
This is so we can remove the [duplicate data type strings](https://github.com/cashapp/sqldelight/blob/913e135ee235fd692673fa54435f63a8eaa01993/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/sqlTypeName.kt#L27-L30) found in SQLDelight.