### PR TITLE
Split out application-level initialization so it happens only once

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlFileBase.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlFileBase.kt
@@ -85,8 +85,9 @@ abstract class SqlFileBase(
     if (includeAll) {
       val orderedContributors = sortedMapOf<Int, LinkedHashSet<SchemaContributor>>()
       val topContributors = LinkedHashSet<SchemaContributor>()
+      val index = SchemaContributorIndex.getInstance(project)
 
-      SchemaContributorIndex.instance.get(T::class.java.name, project, searchScope()).forEach {
+      index.get(T::class.java.name, project, searchScope()).forEach {
         val file = it.containingFile
 
         if (file == this) return@forEach

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/SchemaContributorIndex.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/SchemaContributorIndex.kt
@@ -1,14 +1,31 @@
 package com.alecstrong.sql.psi.core.psi
 
+import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StringStubIndexExtension
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
 
-internal class SchemaContributorIndex : StringStubIndexExtension<SchemaContributor>() {
+internal interface SchemaContributorIndex {
+  fun getKey(): StubIndexKey<String, SchemaContributor>
+  fun get(key: String, project: Project, scope: GlobalSearchScope): Collection<SchemaContributor>
+
+  companion object {
+    internal val KEY by lazy {
+      StubIndexKey.createIndexKey<String, SchemaContributor>("sqldelight.schema")
+    }
+
+    fun getInstance(project: Project): SchemaContributorIndex {
+      return ServiceManager.getService(project, SchemaContributorIndex::class.java)
+          ?: SchemaContributorIndexImpl.instance
+    }
+  }
+}
+
+internal class SchemaContributorIndexImpl : SchemaContributorIndex, StringStubIndexExtension<SchemaContributor>() {
   override fun getKey(): StubIndexKey<String, SchemaContributor> {
-    return KEY
+    return SchemaContributorIndex.KEY
   }
 
   override fun get(
@@ -18,14 +35,11 @@ internal class SchemaContributorIndex : StringStubIndexExtension<SchemaContribut
   ): Collection<SchemaContributor> {
     return StubIndex.getElements<String, SchemaContributor>(getKey(), key,
         project, scope,
-        SchemaContributor::class.java)
+        SchemaContributor::class.java
+    )
   }
 
   companion object {
-    internal val KEY by lazy {
-      StubIndexKey.createIndexKey<String, SchemaContributor>("sqldelight.schema")
-    }
-
-    internal var instance: StringStubIndexExtension<SchemaContributor> = SchemaContributorIndex()
+    val instance: SchemaContributorIndexImpl = SchemaContributorIndexImpl()
   }
 }

--- a/core/src/test/kotlin/com/alecstrong/sql/psi/core/TestHeadlessParser.kt
+++ b/core/src/test/kotlin/com/alecstrong/sql/psi/core/TestHeadlessParser.kt
@@ -11,7 +11,14 @@ internal class TestHeadlessParser {
   private val parserDefinition = TestParserDefinition()
 
   fun build(root: String, annotator: SqlAnnotationHolder): SqlCoreEnvironment {
-    val environment = SqlCoreEnvironment(parserDefinition, TestFileType, listOf(File(root)))
+    val environment = object : SqlCoreEnvironment(listOf(File(root)), emptyList()) {
+      init {
+        initializeApplication {
+          registerFileType(TestFileType, TestFileType.defaultExtension)
+          registerParserDefinition(parserDefinition)
+        }
+      }
+    }
     environment.annotate(annotator)
     return environment
   }

--- a/sample-headless/src/main/kotlin/com/alecstrong/sqlite/psi/sample/headless/SampleHeadlessParser.kt
+++ b/sample-headless/src/main/kotlin/com/alecstrong/sqlite/psi/sample/headless/SampleHeadlessParser.kt
@@ -8,8 +8,14 @@ import java.io.File
 class SampleHeadlessParser {
   fun parseSqlite() {
     val parserDefinition = SampleParserDefinition()
-    val environment = SqlCoreEnvironment(parserDefinition, SampleFileType, listOf(
-        File("sample-headless")))
+    val environment = object : SqlCoreEnvironment(listOf(File("sample-headless")), emptyList()) {
+      init {
+        initializeApplication {
+          registerFileType(SampleFileType, SampleFileType.defaultExtension)
+          registerParserDefinition(parserDefinition)
+        }
+      }
+    }
     environment.annotate(SampleHeadlessAnnotator())
   }
 }

--- a/sample-plugin/src/main/resources/META-INF/plugin.xml
+++ b/sample-plugin/src/main/resources/META-INF/plugin.xml
@@ -15,7 +15,7 @@
     <lang.parserDefinition language="Sample" implementationClass="com.alecstrong.sql.psi.sample.core.SampleParserDefinition" />
     <annotator language="Sample" implementationClass="com.alecstrong.sql.psi.core.SqlAnnotator"/>
     <fileTypeFactory implementation="com.alecstrong.sql.psi.sample.plugin.SampleFileTypeFactory"/>
-    <stubIndex implementation="com.alecstrong.sql.psi.core.psi.SchemaContributorIndex"/>
+    <stubIndex implementation="com.alecstrong.sql.psi.core.psi.SchemaContributorIndexImpl"/>
     <stubElementTypeHolder class="com.alecstrong.sql.psi.core.psi.SqlTypes"/>
   </extensions>
 </idea-plugin>


### PR DESCRIPTION
also fixes the index to be per-project so sqldelight can configure it correctly