### PR TITLE
Prefix SQLite to generated SQLite psi files

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_18/psi/mixins/ColumnDefMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_18/psi/mixins/ColumnDefMixin.kt
@@ -2,7 +2,7 @@ package com.alecstrong.sql.psi.core.sqlite_3_18.psi.mixins
 
 import com.alecstrong.sql.psi.core.psi.SqlTypes
 import com.alecstrong.sql.psi.core.psi.impl.SqlColumnDefImpl
-import com.alecstrong.sql.psi.core.sqlite_3_18.psi.TypeName
+import com.alecstrong.sql.psi.core.sqlite_3_18.psi.SqliteTypeName
 import com.intellij.lang.ASTNode
 
 internal class ColumnDefMixin(node: ASTNode) : SqlColumnDefImpl(node) {
@@ -14,7 +14,7 @@ internal class ColumnDefMixin(node: ASTNode) : SqlColumnDefImpl(node) {
       // https://www.sqlite.org/autoinc.html
       // "On an INSERT, if the ROWID or INTEGER PRIMARY KEY column is not explicitly given a value, then it will be
       // filled automatically with an unused integer .. regardless of whether or not the AUTOINCREMENT keyword is used."
-      (columnType.typeName as TypeName).intDataType != null &&
+      (columnType.typeName as SqliteTypeName).intDataType != null &&
         this.columnConstraintList.any { it.node.findChildByType(SqlTypes.PRIMARY) != null }
       ) ||
       super.hasDefaultValue()

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_18/sqlite.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_18/sqlite.bnf
@@ -5,6 +5,7 @@
 
   implements="com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
   extends="com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl"
+  psiClassPrefix = "Sqlite"
 
   parserImports=[
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DIGIT"

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_24/psi/mixins/InsertStmtMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_24/psi/mixins/InsertStmtMixin.kt
@@ -3,13 +3,13 @@ package com.alecstrong.sql.psi.core.sqlite_3_24.psi.mixins
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.psi.SqlTypes
 import com.alecstrong.sql.psi.core.psi.impl.SqlInsertStmtImpl
-import com.alecstrong.sql.psi.core.sqlite_3_24.psi.InsertStmt
+import com.alecstrong.sql.psi.core.sqlite_3_24.psi.SqliteInsertStmt
 import com.intellij.lang.ASTNode
 
 internal abstract class InsertStmtMixin(
   node: ASTNode
 ) : SqlInsertStmtImpl(node),
-    InsertStmt {
+    SqliteInsertStmt {
   override fun annotate(annotationHolder: SqlAnnotationHolder) {
     super.annotate(annotationHolder)
     val insertDefaultValues = insertStmtValues?.node?.findChildByType(

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_24/psi/mixins/UpsertClauseMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_24/psi/mixins/UpsertClauseMixin.kt
@@ -4,27 +4,27 @@ import com.alecstrong.sql.psi.core.psi.QueryElement
 import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
 import com.alecstrong.sql.psi.core.psi.mixins.InsertStmtMixin
 import com.alecstrong.sql.psi.core.psi.mixins.SingleRow
-import com.alecstrong.sql.psi.core.sqlite_3_24.psi.UpsertClause
-import com.alecstrong.sql.psi.core.sqlite_3_24.psi.UpsertConflictTarget
-import com.alecstrong.sql.psi.core.sqlite_3_24.psi.UpsertDoUpdate
+import com.alecstrong.sql.psi.core.sqlite_3_24.psi.SqliteUpsertClause
+import com.alecstrong.sql.psi.core.sqlite_3_24.psi.SqliteUpsertConflictTarget
+import com.alecstrong.sql.psi.core.sqlite_3_24.psi.SqliteUpsertDoUpdate
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 
 internal abstract class UpsertClauseMixin(
   node: ASTNode
 ) : SqlCompositeElementImpl(node),
-    UpsertClause {
+    SqliteUpsertClause {
 
     override fun queryAvailable(child: PsiElement): Collection<QueryElement.QueryResult> {
         val insertStmt = (this.parent as InsertStmtMixin)
         val tableName = insertStmt.tableName
         val table = tablesAvailable(this).first { it.tableName.name == tableName.name }.query
 
-        if (child is UpsertConflictTarget) {
+        if (child is SqliteUpsertConflictTarget) {
             return super.queryAvailable(child)
         }
 
-        if (child is UpsertDoUpdate) {
+        if (child is SqliteUpsertDoUpdate) {
             val excludedTable = QueryElement.QueryResult(
                 SingleRow(
                     tableName, "excluded"

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_24/sqlite.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_24/sqlite.bnf
@@ -5,6 +5,7 @@
 
   implements="com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
   extends="com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl"
+  psiClassPrefix = "Sqlite"
 
   parserImports=[
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.INSERT"


### PR DESCRIPTION
To keep inline with all the other dialects as well as `sqlite_3_25`.