### PR TITLE
[RFC] Report an error when binding a column name in an ORDER BY clause

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/BinaryComparisonExprMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/BinaryComparisonExprMixin.kt
@@ -1,0 +1,20 @@
+package com.alecstrong.sql.psi.core.psi.mixins
+
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.SqlBinaryExpr
+import com.alecstrong.sql.psi.core.psi.SqlBindExpr
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.intellij.lang.ASTNode
+
+internal abstract class BinaryComparisonExprMixin(
+  node: ASTNode
+) : SqlCompositeElementImpl(node),
+    SqlBinaryExpr {
+  override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    super.annotate(annotationHolder)
+
+    if (firstChild is SqlBindExpr && lastChild is SqlBindExpr) {
+      annotationHolder.createErrorAnnotation(this, "Cannot bind both sides of a binary comparison expression")
+    }
+  }
+}

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/InExprMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/InExprMixin.kt
@@ -1,6 +1,7 @@
 package com.alecstrong.sql.psi.core.psi.mixins
 
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.SqlBindExpr
 import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
 import com.alecstrong.sql.psi.core.psi.SqlInExpr
 import com.intellij.lang.ASTNode
@@ -10,6 +11,10 @@ internal abstract class InExprMixin(
 ) : SqlCompositeElementImpl(node),
     SqlInExpr {
   override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    if (firstChild is SqlBindExpr && lastChild is SqlBindExpr) {
+      annotationHolder.createErrorAnnotation(this, "Cannot bind both sides of an IN expression")
+    }
+
     val query = compoundSelectStmt?.queryExposed()
         ?: tableName?.let { table -> tableAvailable(this, table.name) }
         ?: emptyList()

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/OrderByMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/OrderByMixin.kt
@@ -1,0 +1,20 @@
+package com.alecstrong.sql.psi.core.psi.mixins
+
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.SqlBindExpr
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.alecstrong.sql.psi.core.psi.SqlOrderingTerm
+import com.intellij.lang.ASTNode
+
+internal abstract class OrderByMixin(
+  node: ASTNode
+) : SqlCompositeElementImpl(node),
+    SqlOrderingTerm {
+  override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    super.annotate(annotationHolder)
+
+    if (expr is SqlBindExpr) {
+      annotationHolder.createErrorAnnotation(expr, "Cannot bind the name of a column in an ORDER BY clause")
+    }
+  }
+}

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/ResultColumnMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/ResultColumnMixin.kt
@@ -1,9 +1,11 @@
 package com.alecstrong.sql.psi.core.psi.mixins
 
 import com.alecstrong.sql.psi.core.ModifiableFileLazy
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.psi.FromQuery
 import com.alecstrong.sql.psi.core.psi.QueryElement
 import com.alecstrong.sql.psi.core.psi.QueryElement.QueryResult
+import com.alecstrong.sql.psi.core.psi.SqlBindExpr
 import com.alecstrong.sql.psi.core.psi.SqlColumnExpr
 import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
 import com.alecstrong.sql.psi.core.psi.SqlResultColumn
@@ -49,4 +51,13 @@ internal abstract class ResultColumnMixin(
   }
 
   override fun queryExposed() = queryExposed.forFile(containingFile)
+
+  override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    super.annotate(annotationHolder)
+
+    val bindExpr = expr as? SqlBindExpr
+    if (bindExpr != null) {
+      annotationHolder.createErrorAnnotation(bindExpr, "Cannot bind the name of a column in a SELECT result-column")
+    }
+  }
 }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -239,9 +239,11 @@ binary_bitwise_expr ::= expr ( '<<' |  '>>' | '&' | '|' ) expr {
   implements = "com.alecstrong.sql.psi.core.psi.SqlBinaryExpr"
 }
 binary_boolean_expr ::= expr (  '<' | '<=' | '>' | '>=' ) expr {
+  mixin = "com.alecstrong.sql.psi.core.psi.mixins.BinaryComparisonExprMixin"
   implements = "com.alecstrong.sql.psi.core.psi.SqlBinaryExpr"
 }
 binary_equality_expr ::= expr ( '=' | '==' | '!=' | '<>' ) expr {
+  mixin = "com.alecstrong.sql.psi.core.psi.mixins.BinaryComparisonExprMixin"
   implements = "com.alecstrong.sql.psi.core.psi.SqlBinaryExpr"
 }
 binary_and_expr ::= expr AND expr {
@@ -261,8 +263,12 @@ binary_like_expr ::= expr [ NOT ] ( binary_like_operator ) expr [ ESCAPE expr ] 
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.BinaryLikeExprMixin"
 }
 null_expr ::= expr ( ISNULL | NOTNULL | NOT NULL )
-is_expr ::= expr IS [ NOT ] expr
-between_expr ::= expr [ NOT ] BETWEEN expr AND <<expr '6'>>
+is_expr ::= expr IS [ NOT ] expr {
+  mixin = "com.alecstrong.sql.psi.core.psi.mixins.BinaryComparisonExprMixin"
+}
+between_expr ::= expr [ NOT ] BETWEEN expr AND <<expr '6'>> {
+  mixin = "com.alecstrong.sql.psi.core.psi.mixins.BinaryComparisonExprMixin"
+}
 in_expr ::= expr [ NOT ] IN ( '(' [ compound_select_stmt | expr ( ',' expr ) * ] ')' | [ database_name '.' ] table_name | bind_expr ) {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.InExprMixin"
   pin = 3

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -348,7 +348,9 @@ result_column ::= ( '*'
 join_operator ::= ( ','
                   | [ NATURAL ] [ LEFT [ OUTER ] | INNER | CROSS ] JOIN )
 join_constraint ::= [ ON expr | USING '(' column_name ( ',' column_name ) * ')' ]
-ordering_term ::= expr [ COLLATE collation_name ] [ ASC | DESC ]
+ordering_term ::= expr [ COLLATE collation_name ] [ ASC | DESC ] {
+  mixin = "com.alecstrong.sql.psi.core.psi.mixins.OrderByMixin"
+}
 compound_operator ::= ( UNION ALL
                       | UNION
                       | INTERSECT

--- a/core/src/test/fixtures/bind-failures/Test.s
+++ b/core/src/test/fixtures/bind-failures/Test.s
@@ -1,0 +1,7 @@
+CREATE TABLE test (
+  _id INTEGER NOT NULL
+);
+
+SELECT *
+FROM test
+ORDER BY ?1;

--- a/core/src/test/fixtures/bind-failures/Test.s
+++ b/core/src/test/fixtures/bind-failures/Test.s
@@ -8,3 +8,75 @@ ORDER BY ?1;
 
 SELECT ?
 FROM test;
+
+SELECT *
+FROM test
+WHERE ? = ?;
+
+SELECT *
+FROM test
+WHERE ? == ?;
+
+SELECT *
+FROM test
+WHERE ? <> ?;
+
+SELECT *
+FROM test
+WHERE ? != ?;
+
+SELECT *
+FROM test
+WHERE ? > ?;
+
+SELECT *
+FROM test
+WHERE ? >= ?;
+
+SELECT *
+FROM test
+WHERE ? < ?;
+
+SELECT *
+FROM test
+WHERE ? <= ?;
+
+SELECT *
+FROM test
+WHERE ? IN ?;
+
+SELECT *
+FROM test
+WHERE ? NOT IN ?;
+
+SELECT *
+FROM test
+WHERE ? BETWEEN ? AND ?;
+
+SELECT *
+FROM test
+WHERE ? IS ?;
+
+SELECT *
+FROM test
+WHERE ? IS NOT ?;
+
+SELECT *
+FROM test
+WHERE ? LIKE ?;
+
+SELECT *
+FROM test
+WHERE ? MATCH ?;
+
+SELECT *
+FROM test
+WHERE ? REGEXP ?;
+
+SELECT *
+FROM test
+WHERE ? GLOB ?;
+
+SELECT *
+FROM test
+GROUP BY ? HAVING ?;

--- a/core/src/test/fixtures/bind-failures/Test.s
+++ b/core/src/test/fixtures/bind-failures/Test.s
@@ -5,3 +5,6 @@ CREATE TABLE test (
 SELECT *
 FROM test
 ORDER BY ?1;
+
+SELECT ?
+FROM test;

--- a/core/src/test/fixtures/bind-failures/failure.txt
+++ b/core/src/test/fixtures/bind-failures/failure.txt
@@ -1,2 +1,20 @@
 Test.s line 7:9 - Cannot bind the name of a column in an ORDER BY clause
 Test.s line 9:7 - Cannot bind the name of a column in a SELECT result-column
+Test.s line 14:6 - Cannot bind both sides of a binary comparison expression
+Test.s line 18:6 - Cannot bind both sides of a binary comparison expression
+Test.s line 22:6 - Cannot bind both sides of a binary comparison expression
+Test.s line 26:6 - Cannot bind both sides of a binary comparison expression
+Test.s line 30:6 - Cannot bind both sides of a binary comparison expression
+Test.s line 34:6 - Cannot bind both sides of a binary comparison expression
+Test.s line 38:6 - Cannot bind both sides of a binary comparison expression
+Test.s line 42:6 - Cannot bind both sides of a binary comparison expression
+Test.s line 46:6 - Cannot bind both sides of an IN expression
+Test.s line 50:6 - Cannot bind both sides of an IN expression
+Test.s line 54:6 - Cannot bind both sides of a binary comparison expression
+Test.s line 58:6 - Cannot bind both sides of a binary comparison expression
+Test.s line 62:6 - Cannot bind both sides of a binary comparison expression
+Test.s line 66:6 - Cannot bind both sides of a LIKE expression
+Test.s line 70:6 - Cannot bind both sides of a MATCH expression
+Test.s line 74:6 - Cannot bind both sides of a REGEXP expression
+Test.s line 78:6 - Cannot bind both sides of a GLOB expression
+Test.s line 82:9 - Cannot bind the name of a column in a GROUP BY clause

--- a/core/src/test/fixtures/bind-failures/failure.txt
+++ b/core/src/test/fixtures/bind-failures/failure.txt
@@ -1,0 +1,1 @@
+Test.s line 7:9 - Cannot bind the name of a column in an ORDER BY clause

--- a/core/src/test/fixtures/bind-failures/failure.txt
+++ b/core/src/test/fixtures/bind-failures/failure.txt
@@ -1,1 +1,2 @@
 Test.s line 7:9 - Cannot bind the name of a column in an ORDER BY clause
+Test.s line 9:7 - Cannot bind the name of a column in a SELECT result-column

--- a/core/src/test/fixtures/match-operator/Test.s
+++ b/core/src/test/fixtures/match-operator/Test.s
@@ -53,7 +53,7 @@ FROM book_fts
 JOIN book ON docid = book.id
 WHERE book_fts MATCH title;
 
--- Expected failure: MATCH can't be used on a bind expression
+-- Expected failure: Cannot bind both sides of a MATCH expression
 SELECT book.*
 FROM book_fts
 JOIN book ON docid = book.id

--- a/core/src/test/fixtures/match-operator/failure.txt
+++ b/core/src/test/fixtures/match-operator/failure.txt
@@ -3,6 +3,6 @@ Test.s line 14:25 - Unable to use function MATCH in the requested context
 Test.s line 37:6 - Unable to use function MATCH in the requested context
 Test.s line 43:6 - Unable to use function MATCH in the requested context
 Test.s line 49:6 - Unable to use function MATCH in the requested context
-Test.s line 60:6 - Unable to use function MATCH in the requested context
+Test.s line 60:6 - Cannot bind both sides of a MATCH expression
 Test.s line 66:6 - Unable to use function MATCH in the requested context
 Test.s line 72:6 - Unable to use function MATCH in the requested context

--- a/core/src/test/fixtures/well-formed-selects/Test.s
+++ b/core/src/test/fixtures/well-formed-selects/Test.s
@@ -74,7 +74,7 @@ SELECT _id
 FROM hockey_player
 WHERE ? = ?
 GROUP BY ? HAVING ?
-ORDER BY ? ASC
+ORDER BY first_name ASC
 LIMIT ?;
 
 SELECT count(*)

--- a/core/src/test/fixtures/well-formed-selects/Test.s
+++ b/core/src/test/fixtures/well-formed-selects/Test.s
@@ -72,8 +72,8 @@ ORDER BY age;
 
 SELECT _id
 FROM hockey_player
-WHERE ? = ?
-GROUP BY ? HAVING ?
+WHERE first_name = ? OR ? = first_name
+GROUP BY first_name HAVING ?
 ORDER BY first_name ASC
 LIMIT ?;
 


### PR DESCRIPTION
Attempting to address https://github.com/cashapp/sqldelight/issues/1187

@AlecStrong Is this the right approach, and does it need to be broadened to other areas besides ORDER BY?