### PR TITLE
Replace text equality checks with textMatches

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/mysql/psi/mixins/AlterTableChangeColumnMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/mysql/psi/mixins/AlterTableChangeColumnMixin.kt
@@ -29,7 +29,7 @@ internal abstract class AlterTableChangeColumnMixin(
           val columns = placementClause.placeInQuery(
               columns = lazyQuery.query.columns,
               column = QueryElement.QueryColumn(columnDef.columnName),
-              replace = lazyQuery.query.columns.singleOrNull { (it.element as SqlColumnName).text == columnName.text }
+              replace = lazyQuery.query.columns.singleOrNull { (it.element as SqlColumnName).textMatches(columnName) }
           )
           lazyQuery.query.copy(columns = columns)
         }
@@ -40,9 +40,9 @@ internal abstract class AlterTableChangeColumnMixin(
     super.annotate(annotationHolder)
 
     if (tablesAvailable(this)
-            .filter { it.tableName.text == alterStmt.tableName?.text }
+            .filter { it.tableName.textMatches(alterStmt.tableName) }
             .flatMap { it.query.columns }
-            .none { (it.element as? SqlColumnName)?.text == columnName.text }) {
+            .none { (it.element as? SqlColumnName)?.textMatches(columnName) == true }) {
       annotationHolder.createErrorAnnotation(
           element = columnDef.columnName,
           s = "No column found to modify with name ${columnDef.columnName.text}"

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/mysql/psi/mixins/AlterTableModifyColumnMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/mysql/psi/mixins/AlterTableModifyColumnMixin.kt
@@ -26,7 +26,7 @@ internal abstract class AlterTableModifyColumnMixin(
           val columns = placementClause.placeInQuery(
               columns = lazyQuery.query.columns,
               column = QueryElement.QueryColumn(columnDef.columnName),
-              replace = lazyQuery.query.columns.singleOrNull { (it.element as SqlColumnName).text == columnDef.columnName.text }
+              replace = lazyQuery.query.columns.singleOrNull { (it.element as SqlColumnName).textMatches(columnDef.columnName) }
           )
           lazyQuery.query.copy(columns = columns)
         }
@@ -37,9 +37,9 @@ internal abstract class AlterTableModifyColumnMixin(
     super.annotate(annotationHolder)
 
     if (tablesAvailable(this)
-        .filter { it.tableName.text == alterStmt.tableName?.text }
+        .filter { it.tableName.textMatches(alterStmt.tableName) }
         .flatMap { it.query.columns }
-        .none { (it.element as? SqlColumnName)?.text == columnDef.columnName.text }) {
+        .none { (it.element as? SqlColumnName)?.textMatches(columnDef.columnName) == true }) {
       annotationHolder.createErrorAnnotation(
           element = columnDef.columnName,
           s = "No column found to modify with name ${columnDef.columnName.text}"

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/mysql/psi/mixins/PlacementClause.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/mysql/psi/mixins/PlacementClause.kt
@@ -21,7 +21,7 @@ internal fun MySqlPlacementClause?.placeInQuery(
     columns.toMutableList().apply {
       if (replace != null) remove(replace)
 
-      val index = indexOfFirst { (it.element as SqlColumnName).text == columnName!!.text }
+      val index = indexOfFirst { (it.element as SqlColumnName).textMatches(columnName!!) }
       if (index == -1) throw AnnotationException(
           msg = "Unable to replace $replace with $column after $columnName in $columns",
           element = this@placeInQuery

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/AlterTableMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/AlterTableMixin.kt
@@ -77,7 +77,7 @@ internal abstract class AlterTableMixin private constructor(
     if (child in alterTableRulesList) {
       check(child is SqlAlterTableRules)
       return tablesAvailable(this)
-          .filter { it.tableName.text == tableName.text }
+          .filter { it.tableName.textMatches(tableName) }
           .map { it.withAlterStatement(this, until = child).query }
     }
     return super.queryAvailable(child)

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/BinaryLikeExprMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/BinaryLikeExprMixin.kt
@@ -80,7 +80,7 @@ internal abstract class BinaryLikeExprMixin(
       queryAvailable(expression)
           .filter { it.table?.name == table.tableName.name }
           .any { query ->
-            query.columns.filter { it.element.text == expression.columnName.name }.any { it.nullable }
+            query.columns.filter { it.element.textMatches(expression.columnName.name) }.any { it.nullable }
           }
     } else {
       true

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateIndexMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateIndexMixin.kt
@@ -47,7 +47,7 @@ internal abstract class CreateIndexMixin(
   override fun annotate(annotationHolder: SqlAnnotationHolder) {
     if (node.findChildByType(SqlTypes.EXISTS) == null &&
         containingFile.schema<SqlCreateIndexStmt>(this)
-            .any { it != this && it.indexName.text == indexName.text }) {
+            .any { it != this && it.indexName.textMatches(indexName) }) {
       annotationHolder.createErrorAnnotation(indexName, "Duplicate index name ${indexName.text}")
     }
     super.annotate(annotationHolder)

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateTriggerMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateTriggerMixin.kt
@@ -65,7 +65,7 @@ internal abstract class CreateTriggerMixin(
   override fun annotate(annotationHolder: SqlAnnotationHolder) {
     if (node.findChildByType(SqlTypes.EXISTS) == null &&
         containingFile.schema<SqlCreateTriggerStmt>(this)
-            .any { it != this && it.triggerName.text == triggerName.text }) {
+            .any { it != this && it.triggerName.textMatches(triggerName) }) {
       annotationHolder.createErrorAnnotation(triggerName,
           "Duplicate trigger name ${triggerName.text}")
     }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/DropIndexMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/DropIndexMixin.kt
@@ -38,7 +38,7 @@ internal abstract class DropIndexMixin private constructor(
     indexName?.let { indexName ->
       if (node.findChildByType(SqlTypes.EXISTS) == null &&
           containingFile.schema<SqlCreateIndexStmt>(this)
-              .none { it != this && it.indexName.text == indexName.text }) {
+              .none { it != this && it.indexName.textMatches(indexName) }) {
         annotationHolder.createErrorAnnotation(indexName,
             "No index found with name ${indexName.text}")
       }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/DropTriggerMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/DropTriggerMixin.kt
@@ -37,7 +37,7 @@ internal abstract class DropTriggerMixin(
     triggerName?.let { triggerName ->
       if (node.findChildByType(SqlTypes.EXISTS) == null &&
           containingFile.schema<SqlCreateTriggerStmt>(this)
-              .none { it != this && it.triggerName.text == triggerName.text }) {
+              .none { it != this && it.triggerName.textMatches(triggerName) }) {
         annotationHolder.createErrorAnnotation(triggerName,
             "No trigger found with name ${triggerName.text}")
       }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_25/psi/mixins/AlterTableRenameColumnMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sqlite_3_25/psi/mixins/AlterTableRenameColumnMixin.kt
@@ -29,7 +29,7 @@ internal abstract class AlterTableRenameColumnMixin(
           val columns = lazyQuery.query.columns
           val column = QueryElement.QueryColumn(element = columnAlias)
           val replace = columns.singleOrNull {
-            (it.element as SqlColumnName).text == columnName.text
+            (it.element as SqlColumnName).textMatches(columnName)
           }
           lazyQuery.query.copy(
               columns = lazyQuery.query.columns.map { if (it == replace) column else it }
@@ -42,9 +42,9 @@ internal abstract class AlterTableRenameColumnMixin(
     super.annotate(annotationHolder)
 
     if (tablesAvailable(this)
-            .filter { it.tableName.text == alterStmt.tableName?.text }
+            .filter { it.tableName.textMatches(alterStmt.tableName) }
             .flatMap { it.query.columns }
-            .none { (it.element as? SqlColumnName)?.text == columnName.text }) {
+            .none { (it.element as? SqlColumnName)?.textMatches(columnName) == true }) {
       annotationHolder.createErrorAnnotation(
           element = columnName,
           s = "No column found to modify with name ${columnName.text}"


### PR DESCRIPTION
https://plugins.jetbrains.com/docs/intellij/performance.html#avoid-expensive-methods-in-psielement

> getText() traverses the whole tree under the given element and concatenates strings, consider textMatches() instead.