### PR TITLE
Fix a compiler warning

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlParserDefinition.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlParserDefinition.kt
@@ -29,6 +29,6 @@ abstract class SqlParserDefinition : ParserDefinition {
 
   override fun createParser(project: Project) = SqlParser()
 
-  abstract override fun createFile(p0: FileViewProvider): SqlFileBase
+  abstract override fun createFile(viewProvider: FileViewProvider): SqlFileBase
   abstract fun getLanguage(): Language
 }

--- a/core/src/test/kotlin/com/alecstrong/sql/psi/core/TestHeadlessParser.kt
+++ b/core/src/test/kotlin/com/alecstrong/sql/psi/core/TestHeadlessParser.kt
@@ -33,7 +33,7 @@ private object TestFileType : LanguageFileType(TestLanguage) {
 }
 
 private class TestParserDefinition : SqlParserDefinition() {
-  override fun createFile(p0: FileViewProvider) = TestFile(p0)
+  override fun createFile(viewProvider: FileViewProvider) = TestFile(viewProvider)
   override fun getFileNodeType() = FILE
   override fun getLanguage() = TestLanguage
 

--- a/sample-core/src/main/kotlin/com/alecstrong/sql/psi/sample/core/SampleParserDefinition.kt
+++ b/sample-core/src/main/kotlin/com/alecstrong/sql/psi/sample/core/SampleParserDefinition.kt
@@ -10,7 +10,7 @@ class SampleParserDefinition : SqlParserDefinition() {
     SampleSqliteParserUtil.overrideSqlParser()
   }
 
-  override fun createFile(fileViewProvider: FileViewProvider) = SampleFile(fileViewProvider)
+  override fun createFile(viewProvider: FileViewProvider) = SampleFile(viewProvider)
   override fun getFileNodeType() = FILE
   override fun getLanguage() = SampleLanguage
 


### PR DESCRIPTION
Fixes the following warning in this repository as well as in [SQLDelight](https://github.com/cashapp/sqldelight/blob/c52f53319662c7386bcf3d9a0dbf8d77c509247a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/MigrationParserDefinition.kt#L14):

> The corresponding parameter in the supertype 'SqlParserDefinition' is named 'p0'. This may cause problems when calling this function with named arguments.
