### PR TITLE
Fix dependency not resolving

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ buildscript {
   }
   repositories {
     mavenCentral()
+    maven { url 'https://dl.bintray.com/kotlin/dokka' }
     maven { url 'https://jitpack.io' }
   }
 


### PR DESCRIPTION
`master` is currently failing as a result of #251. Fixed Dokka dependency per [the documentation](https://github.com/Kotlin/dokka#using-the-gradle-plugin).

~Just commenting out the Gradle cache step to ensure the artifact isn't resolved via the cache. Will revert once the build succeeds.~