### PR TITLE
Fix kotlinx.html dependency not resolving

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
   repositories {
     mavenCentral()
     maven { url 'https://dl.bintray.com/kotlin/dokka' }
+    maven { url 'https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven' }
     maven { url 'https://jitpack.io' }
   }
 


### PR DESCRIPTION
[`master` is failing](https://github.com/AlecStrong/sql-psi/runs/2290423867?check_suite_focus=true) because `org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.2` couldn't be resolved. Added the Maven url per [the documentation](https://github.com/kotlin/kotlinx.html/wiki/Getting-started#gradle).

(Sorry for all the spam)