### PR TITLE
Show column types in autocomplete

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/SqlColumnReference.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/SqlColumnReference.kt
@@ -84,7 +84,15 @@ internal class SqlColumnReference<T : SqlNamedElementImpl>(
   private fun List<PsiElement?>.toLookupArray(): Array<Any> = filterIsInstance<PsiNamedElement>()
     .distinctBy { it.name }
     .filter { it.isValid }
-    .map { LookupElementBuilder.create(it) }
+    .map {
+      if (it is SqlColumnName) {
+        val sqlColumnDef = it.reference?.resolve()?.parent as? SqlColumnDef
+        LookupElementBuilder.create(it)
+          .withTypeText(sqlColumnDef?.columnType?.text)
+      } else {
+        LookupElementBuilder.create(it)
+      }
+    }
     .toTypedArray()
 
   /**


### PR DESCRIPTION
this should fix https://github.com/cashapp/sqldelight/issues/2333