### PR TITLE
PostgreSQL JSONB and ON Conflict Do Nothing

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/PostgreSql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/PostgreSql.bnf
@@ -102,7 +102,7 @@ date_data_type ::= 'DATE' | (('TIME' | 'TIMESTAMP') [ '(' {signed_number} ')' ])
 
 boolean_data_type ::= 'BOOLEAN' | 'BOOL'
 
-json_data_type ::= 'JSON'
+json_data_type ::= 'JSON' | 'JSONB'
 
 with_clause_auxiliary_stmt ::= {compound_select_stmt} | delete_stmt_limited | insert_stmt | update_stmt_limited {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlWithClauseAuxiliaryStmtImpl"

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/PostgreSql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/PostgreSql.bnf
@@ -13,9 +13,11 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ASC"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.BY"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.COLLATE"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.CONFLICT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.CONSTRAINT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DELETE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DESC"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.DO"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.FAIL"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.FROM"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.IGNORE"
@@ -24,8 +26,10 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.KEY"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.LIMIT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.NOT"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.NOTHING"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.NULL"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.OFFSET"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.ON"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.OR"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ORDER"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.PRIMARY"
@@ -116,7 +120,10 @@ delete_stmt_limited ::= [ {with_clause} ] DELETE FROM {qualified_table_name} [ W
   override = true
 }
 
-insert_stmt ::= [ {with_clause} ] ( INSERT OR REPLACE | REPLACE | INSERT OR ROLLBACK | INSERT OR ABORT | INSERT OR FAIL | INSERT OR IGNORE | INSERT ) INTO [ {database_name} '.' ] {table_name} [ AS {table_alias} ] [ '(' {column_name} ( ',' {column_name} ) * ')' ] {insert_stmt_values} [ returning_clause ] {
+insert_stmt ::= [ {with_clause} ]
+    INSERT INTO [ {database_name} '.' ] {table_name} [ AS {table_alias} ]
+    [ '(' {column_name} ( ',' {column_name} ) * ')' ]
+    {insert_stmt_values} [ ON CONFLICT DO NOTHING ] [ returning_clause ] {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlInsertStmtImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlInsertStmt"
   override = true

--- a/core/src/test/fixtures_postgresql/column_types/Sample.s
+++ b/core/src/test/fixtures_postgresql/column_types/Sample.s
@@ -29,5 +29,6 @@ CREATE TABLE all_types(
   some_timestamp TIMESTAMP,
   some_boolean BOOLEAN,
   some_bool BOOL,
-  some_json JSON
+  some_json JSON,
+  some_jsonb JSONB
 );

--- a/core/src/test/fixtures_postgresql/upsert/DoNothing.s
+++ b/core/src/test/fixtures_postgresql/upsert/DoNothing.s
@@ -1,0 +1,9 @@
+CREATE TABLE test7 (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(100) NOT NULL
+);
+
+INSERT INTO test7 (id, name)
+VALUES (1, 'bob')
+ON CONFLICT DO NOTHING
+;


### PR DESCRIPTION
This adds support for:
- Using the JSONB column data type, addressing #193 
- Using ON CONFLICT DO NOTHING with INSERT, partially addressing #136 

Keen to implement the additional conflict target and action assign branches of the BNF too.
Just getting the easy variant out of the way, which would have helped me today :)