### PR TITLE
Adds support for PostgreSQL ON CONFLICT (column, ...) DO UPDATE

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/PostgreSql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/PostgreSql.bnf
@@ -137,7 +137,7 @@ conflict_update ::= DO UPDATE SET conflict_assign ( ',' conflict_assign * )
 
 conflict_assign ::= {column_name} '=' conflict_value
 
-conflict_value ::= {expr | DEFAULT}
+conflict_value ::= <<expr '-1'>> | DEFAULT
 
 update_stmt_limited ::= [ {with_clause} ] UPDATE [ OR ROLLBACK | OR ABORT | OR REPLACE | OR FAIL | OR IGNORE ] {qualified_table_name} SET {column_name} '=' {setter_expression} {update_stmt_subsequent_setter} * [ WHERE <<expr '-1'>> ] [ [ ORDER BY {ordering_term} ( ',' {ordering_term} ) * ] LIMIT <<expr '-1'>> [ ( OFFSET | ',' ) <<expr '-1'>> ] ] [ returning_clause ] {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlUpdateStmtLimitedImpl"

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/PostgreSql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/postgresql/PostgreSql.bnf
@@ -122,12 +122,22 @@ delete_stmt_limited ::= [ {with_clause} ] DELETE FROM {qualified_table_name} [ W
 
 insert_stmt ::= [ {with_clause} ]
     INSERT INTO [ {database_name} '.' ] {table_name} [ AS {table_alias} ]
-    [ '(' {column_name} ( ',' {column_name} ) * ')' ]
-    {insert_stmt_values} [ ON CONFLICT DO NOTHING ] [ returning_clause ] {
+    [ '(' {column_name} ( ',' {column_name} ) * ')' ] {insert_stmt_values}
+    [ ON CONFLICT ( [conflict_target] DO NOTHING | conflict_target conflict_update ) ]
+    [ returning_clause ] {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlInsertStmtImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlInsertStmt"
   override = true
 }
+
+
+conflict_target ::= '(' {column_name} ( ',' {column_name} ) * ')'
+
+conflict_update ::= DO UPDATE SET conflict_assign ( ',' conflict_assign * )
+
+conflict_assign ::= {column_name} '=' conflict_value
+
+conflict_value ::= {expr | DEFAULT}
 
 update_stmt_limited ::= [ {with_clause} ] UPDATE [ OR ROLLBACK | OR ABORT | OR REPLACE | OR FAIL | OR IGNORE ] {qualified_table_name} SET {column_name} '=' {setter_expression} {update_stmt_subsequent_setter} * [ WHERE <<expr '-1'>> ] [ [ ORDER BY {ordering_term} ( ',' {ordering_term} ) * ] LIMIT <<expr '-1'>> [ ( OFFSET | ',' ) <<expr '-1'>> ] ] [ returning_clause ] {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlUpdateStmtLimitedImpl"

--- a/core/src/test/fixtures_postgresql/upsert/DoNothing.s
+++ b/core/src/test/fixtures_postgresql/upsert/DoNothing.s
@@ -7,3 +7,18 @@ INSERT INTO test7 (id, name)
 VALUES (1, 'bob')
 ON CONFLICT DO NOTHING
 ;
+
+INSERT INTO test7 (id, name)
+VALUES (1, 'bob')
+ON CONFLICT (id) DO NOTHING
+;
+
+INSERT INTO test7 (id, name)
+VALUES (1, 'bob')
+ON CONFLICT (name) DO NOTHING
+;
+
+INSERT INTO test7 (id, name)
+VALUES (1, 'bob')
+ON CONFLICT (missing_column) DO NOTHING
+;

--- a/core/src/test/fixtures_postgresql/upsert/DoUpdate.s
+++ b/core/src/test/fixtures_postgresql/upsert/DoUpdate.s
@@ -22,3 +22,8 @@ INSERT INTO test8 (id, name)
 VALUES (1, 'bob')
 ON CONFLICT (id, name) DO UPDATE SET name = DEFAULT
 ;
+
+INSERT INTO test8 (id, name)
+VALUES (1, 'bob')
+ON CONFLICT (id, name) DO UPDATE SET name = 'new' || name
+;

--- a/core/src/test/fixtures_postgresql/upsert/DoUpdate.s
+++ b/core/src/test/fixtures_postgresql/upsert/DoUpdate.s
@@ -1,0 +1,24 @@
+CREATE TABLE test8 (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(100) NOT NULL
+);
+
+INSERT INTO test8 (id, name)
+VALUES (1, 'bob')
+ON CONFLICT DO UPDATE SET name = name
+;
+
+INSERT INTO test8 (id, name)
+VALUES (1, 'bob')
+ON CONFLICT (id) DO UPDATE SET name = name
+;
+
+INSERT INTO test8 (id, name)
+VALUES (1, 'bob')
+ON CONFLICT (id) DO UPDATE SET name = excluded.name
+;
+
+INSERT INTO test8 (id, name)
+VALUES (1, 'bob')
+ON CONFLICT (id, name) DO UPDATE SET name = DEFAULT
+;

--- a/core/src/test/fixtures_postgresql/upsert/failure.txt
+++ b/core/src/test/fixtures_postgresql/upsert/failure.txt
@@ -1,0 +1,2 @@
+DoNothing.s line 23:13 - No column found with name missing_column
+DoUpdate.s line 8:15 - NOTHING expected, got 'UPDATE'


### PR DESCRIPTION
More support for PostgreSQL UPSERT #136

Supports conflict clause for DO NOTHING actions.
Conflict clauses support inferred indices only.
Supports ON CONFLICT DO UPDATE action.
The DO UPDATE action can refer to the excluded values and default column values.
No support for WHERE on DO UPDATE action.
Added positive/negative tests for DO NOTHING and DO UPDATE.