### PR TITLE
Automatically add labels for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Valid SQL syntax is not supported
 title: ''
-labels: ''
+labels: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea
 title: ''
-labels: ''
+labels: feature
 assignees: ''
 
 ---


### PR DESCRIPTION
The vast majority of issues in this repository is regarding SQL that is failing (i.e., bugs), so automatically adding these labels will mostly help by being able to weed out the feature requests.

Automatically adding labels is also done in SQLDelight with their [feature](https://github.com/cashapp/sqldelight/blob/master/.github/ISSUE_TEMPLATE/5-feature_request.md) and [bug](https://github.com/cashapp/sqldelight/blob/master/.github/ISSUE_TEMPLATE/2-compilation-issue.md) issue templates.