### PR TITLE
Don't run GitHub Actions on Markdown files

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '*.md'
+  pull_request:
+    paths-ignore:
+      - '*.md'
 
 jobs:
   build:


### PR DESCRIPTION
I just noticed that https://github.com/AlecStrong/sql-psi/pull/275 is running the CI, yet I only changed a couple of markdown files. It's pretty pointless running CI when we've only edited some markdown files, so we can safely skip it in these cases.