### PR TITLE
Improve compatibility with older IntelliJ versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ allprojects {
   tasks.withType(KotlinCompile) {
     kotlinOptions {
       jvmTarget = "1.8"
+      apiVersion = "1.3"
     }
   }
 


### PR DESCRIPTION
IntelliJ 2020.2 (min version supported by SQLDelight) bundles Kotlin 1.3.70: https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library.

Running SQLDelight on 2020.2 with bundled Kotlin causes failures when calling this module as it's built against API version higher than 1.4, see https://youtrack.jetbrains.com/issue/KT-39389.