### PR TITLE
Add jitpack.io to non-buildscript dependency resolution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ allprojects {
     mavenCentral()
     maven { url 'https://www.jetbrains.com/intellij-repository/releases' }
     maven { url "https://cache-redirector.jetbrains.com/intellij-dependencies" }
+    maven { url 'https://jitpack.io' }
   }
 
   group = GROUP


### PR DESCRIPTION
The Grammar-Kit dependency was being obtained from jetbrains' bintray
repository which has been throwing 502 errors, preventing compilation of
this project on blank gradle caches.

This patch allows it to be fetched from jitpack.

Closes #306