### PR TITLE
Correctly set a pin for update statements

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -370,18 +370,21 @@ compound_operator ::= ( UNION ALL
                       | INTERSECT
                       | EXCEPT )
 update_stmt ::= [ with_clause ] UPDATE [ OR ROLLBACK | OR ABORT | OR REPLACE | OR FAIL | OR IGNORE ] qualified_table_name
-  SET (( column_name '=' setter_expression update_stmt_subsequent_setter * ) | ( '(' column_name ( ',' column_name ) * ')' ) '=' ( '(' setter_expression ( ',' setter_expression ) * ')' ))
+  update_set_clause
   [ WHERE expr ] {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.MutatorMixin"
   pin = 4
 }
 update_stmt_limited ::= [ with_clause ] UPDATE [ OR ROLLBACK | OR ABORT | OR REPLACE | OR FAIL | OR IGNORE ] qualified_table_name
-  SET (( column_name '=' setter_expression update_stmt_subsequent_setter * ) | ( '(' column_name ( ',' column_name ) * ')' ) '=' ( '(' setter_expression ( ',' setter_expression ) * ')' ))
+  update_set_clause
   [ WHERE expr ]
   [ [ ORDER BY ordering_term ( ',' ordering_term ) * ]
   LIMIT expr [ ( OFFSET | ',' ) expr ] ] {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.MutatorMixin"
   pin = 4
+}
+private update_set_clause ::= SET (( column_name '=' setter_expression update_stmt_subsequent_setter * ) | ( '(' column_name ( ',' column_name ) * ')' ) '=' ( '(' setter_expression ( ',' setter_expression ) * ')' )) {
+  pin(".*") = 1
 }
 update_stmt_subsequent_setter ::= ',' column_name '=' setter_expression {
   pin = 1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ truth = "com.google.truth:truth:1.1.3"
 
 [plugins]
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-grammarKitComposer = { id = "com.alecstrong.grammar.kit.composer", version = "0.1.7" }
+grammarKitComposer = { id = "com.alecstrong.grammar.kit.composer", version = "0.1.8" }
 spotless = { id = "com.diffplug.spotless", version = "6.4.2" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.19.0" }
 dokka = { id = "org.jetbrains.dokka", version = "1.6.10" }


### PR DESCRIPTION
`private` rules are important, they dont actually exist in the generated code, so children of private rules just get inlined into the parent. So this change doesn't actually change the generated API at all since I just moved some rules into a private rule.

However, that lets me be specific about how separate parts of the grammar are `pinned`. Pinning is when the parser sees a specific element has been typed and decides "I am definitely parsing this rule". So for an UPDATE if you've typed

```
UPDATE foo
```

it knows it is an update statement.

The private rule is important because theres actually two ways to write updates now:

```
UPDATE foo
SET (bar
```

```
UPDATE foo
SET bar
```

So I create a separate pin on specifically sub expressions ( that is what `pin(".*")` does) on the first element seen. So if you type

```
UPDATE foo
SET bar
```

it knows that its a column name, and if you type

```
UPDATE foo
SET (
```

it also knows the next thing is a column name.

I don't know why I'm explaining all this, probably to justify the two hours I spent figuring this out