### PR TITLE
Crash early when an invalid element is getting returned

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/QueryElement.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/QueryElement.kt
@@ -48,7 +48,11 @@ interface QueryElement : PsiElement {
     val nullable: Boolean? = null,
     val compounded: List<QueryColumn> = emptyList(),
     val hiddenByUsing: Boolean = false
-  )
+  ) {
+    init {
+      if (!element.isValid) throw InvalidElementDetectedException()
+    }
+  }
 
   /**
    * These aren't considered part of the exposed query (ie performing a SELECT * does not return
@@ -62,3 +66,11 @@ interface QueryElement : PsiElement {
 }
 
 internal fun List<PsiElement>.asColumns() = map { QueryColumn(it) }
+
+/**
+ * This usually happens during a long running operation on a read thread when a file is rewritten
+ * and some elements are made invalid. In most cases it's safe to catch and ignore this exception
+ * since your task will be invoked again by the IDE. (And this should never happen from a headless
+ * environment).
+ */
+class InvalidElementDetectedException : IllegalStateException()

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/SqlColumnReference.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/SqlColumnReference.kt
@@ -25,9 +25,9 @@ internal class SqlColumnReference<T : SqlNamedElementImpl>(
     }
   }
 
-  override fun resolve() = resolved.forFile(element.containingFile)?.element
+  override fun resolve() = if (!element.isValid) throw InvalidElementDetectedException() else resolved.forFile(element.containingFile)?.element
 
-  internal fun resolveToQuery(): QueryColumn? = resolved.forFile(element.containingFile)
+  internal fun resolveToQuery(): QueryColumn? = if (!element.isValid) throw InvalidElementDetectedException() else resolved.forFile(element.containingFile)
 
   internal fun unsafeResolve(): QueryColumn? {
     if (element.parent is SqlColumnDef || element.parent is CreateVirtualTableMixin) return QueryColumn(element)


### PR DESCRIPTION
This happens most often when the file being edited is also being compiled. There will also be a SQLDelight change to handle these exceptions and fail gracefully since its okay if we just wait for a valid PSI tree before compiling