### PR TITLE
Add Mixing for BindingParameter to use it in sqldelight

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/BindParameterMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/BindParameterMixin.kt
@@ -1,0 +1,23 @@
+package com.alecstrong.sql.psi.core.psi.mixins
+
+import com.alecstrong.sql.psi.core.psi.SqlBindParameter
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.intellij.lang.ASTNode
+
+abstract class BindParameterMixin(node: ASTNode) : SqlCompositeElementImpl(node), SqlBindParameter {
+  /**
+   * Overwrite, if the user provided sql parameter should be overwritten by code generators with [replaceWith].
+   *
+   * Some sql dialects support other bind parameter besides `?`, but the code generator should still replace the
+   * user provided parameter with [replaceWith] for a homogen generated code.
+   */
+  open val replaceWith: String = text
+
+  /**
+   * If true, this parameter is not used by code generators during parameter mapping.
+   *
+   * Some sql dialects support generated and default columns, so a code generator should skip this parameter to not
+   * require and map it from the given parameters.
+   */
+  open val isDefault: Boolean = false
+}

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -458,6 +458,8 @@ view_name ::= id | string {
 }
 module_name ::= id
 module_argument_name ::= id
-bind_parameter ::= '?'
+bind_parameter ::= '?' {
+  mixin = "com.alecstrong.sql.psi.core.psi.mixins.BindParameterMixin"
+}
 table_options ::= table_option ( [','] table_option ) *
 table_option ::= WITHOUT ROWID


### PR DESCRIPTION
Related to https://github.com/cashapp/sqldelight/pull/3375

Option 1: Define the mixin in sql-psi

Alternative: Define the mixin in sqldelight, because its usage is only in code generator, not in compiler frontend