### PR TITLE
add multiple column where fixture

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -205,6 +205,7 @@ expr ::= ( other_expr
          | raise_expr
          | case_expr
          | exists_expr
+         | multi_column_expr
          | paren_expr
          | binary_or_expr
          | binary_and_expr
@@ -228,7 +229,7 @@ expr ::= ( other_expr
          | bind_expr )
 
 other_expr ::= extension_expr
-extension_expr ::= NULL | multi_column_expr
+extension_expr ::= NULL
 extension_stmt ::= NULL
 multi_column_expr ::= values_expression [ ( LT | LTE | GT | GTE ) values_expression ] {
   pin = 1

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -201,7 +201,8 @@ drop_view_stmt ::= DROP VIEW [ IF EXISTS ] [ database_name '.' ] view_name {
   stubClass = "com.alecstrong.sql.psi.core.psi.SchemaContributorStub"
   pin = 2
 }
-expr ::= ( raise_expr
+expr ::= ( other_expr
+         | raise_expr
          | case_expr
          | exists_expr
          | paren_expr
@@ -223,13 +224,15 @@ expr ::= ( raise_expr
          | binary_pipe_expr
          | unary_expr
          | literal_expr
-         | other_expr
          | column_expr
          | bind_expr )
 
 other_expr ::= extension_expr
-extension_expr ::= NULL
+extension_expr ::= NULL | multi_column_expr
 extension_stmt ::= NULL
+multi_column_expr ::= values_expression [ ( LT | LTE | GT | GTE ) values_expression ] {
+  pin = 1
+}
 literal_expr ::= literal_value
 bind_expr ::= bind_parameter
 column_expr ::= [ database_name '.' table_name '.' | table_name '.' ] column_name

--- a/test-fixtures/src/main/resources/fixtures/multiple-column-where/Test.s
+++ b/test-fixtures/src/main/resources/fixtures/multiple-column-where/Test.s
@@ -1,0 +1,12 @@
+CREATE TABLE posts (
+  id TEXT NOT NULL PRIMARY KEY,
+  text TEXT,
+  created_at INTEGER NOT NULL
+);
+
+-- works fine.
+SELECT *
+FROM posts
+WHERE (id, created_at) <= (?, ?)
+ORDER BY created_at DESC
+LIMIT 4;

--- a/test-fixtures/src/main/resources/fixtures/multiple-column-where/Test.s
+++ b/test-fixtures/src/main/resources/fixtures/multiple-column-where/Test.s
@@ -10,3 +10,8 @@ FROM posts
 WHERE (id, created_at) <= (?, ?)
 ORDER BY created_at DESC
 LIMIT 4;
+
+-- should fail.
+SELECT *
+FROM posts
+WHERE (id, ) <= (?, ?)

--- a/test-fixtures/src/main/resources/fixtures/multiple-column-where/failure.txt
+++ b/test-fixtures/src/main/resources/fixtures/multiple-column-where/failure.txt
@@ -1,0 +1,1 @@
+Test.s line 17:9 - '(', ')', ',', '.', <binary like operator real>, BETWEEN or IN expected, got ','


### PR DESCRIPTION
Hey, 
I was trying to achieve [stable pagination](https://gist.github.com/sphrak/c0824be44151636a8bfbcd8dc04df40b) with sqlite and figured I'd try the same with sqldelight however its currently not too thrilled about it.

I attempted to add my own rule, something like this;
```bnf
multi_column_expr ::= '(' expr ( ',' expr ) * ')' (  '<' | '<=' | '>' | '>=' ) '(' expr ( ',' expr ) * ')' {
  pin = 1
}
```
.. but ill admit im just guessting here and then I read in contributing.md that `expr` is a special case that cannot be overridden? so im a tad bit confused on how I could proceed because it would be quite neat if this worked, but im not sure how to proceed.

https://github.com/AlecStrong/sql-psi/issues/273 seems kinda similar or at least a little bit related.

I attached a test fixture that fails with:
```sh
ava.lang.AssertionError: Test failed because the compile output unexpectedly has the errors <[
    Test.s line 10:9 - '(', ')', '.', <binary like operator real>, BETWEEN or IN expected, got ','
]>. 
Overall we expected to see no errors but got the errors <[
    Test.s line 10:9 - '(', ')', '.', <binary like operator real>, BETWEEN or IN expected, got ','
]>
	at com.alecstrong.sql.psi.test.fixtures.FixturesTest.execute(FixturesTest.kt:89)
	at jdk.internal.reflect.GeneratedMethodAccessor2.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:133)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)```