### PR TITLE
Support functions in index

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -106,7 +106,7 @@ create_index_stmt ::= CREATE [ UNIQUE ] INDEX [ IF NOT EXISTS ] [ database_name 
   stubClass = "com.alecstrong.sql.psi.core.psi.SchemaContributorStub"
   pin = 6
 }
-indexed_column ::= [ column_name | expr ] [ COLLATE collation_name ] [ ASC | DESC ]
+indexed_column ::= expr [ COLLATE collation_name ] [ ASC | DESC ]
 create_table_stmt ::= CREATE [ TEMP | TEMPORARY ] TABLE [ IF NOT EXISTS ] [ database_name '.' ] table_name ( '(' column_def ( ',' column_def ) * ( ',' table_constraint ) * ')' [ table_options ] | AS compound_select_stmt ) {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.CreateTableMixin"
   implements = "com.alecstrong.sql.psi.core.psi.TableElement"

--- a/test-fixtures/src/main/resources/fixtures/create-index-validation-failures/Test.s
+++ b/test-fixtures/src/main/resources/fixtures/create-index-validation-failures/Test.s
@@ -14,3 +14,7 @@ WHERE column1 IS NOT NULL;
 -- valid.
 CREATE INDEX index_3
 ON test (_id COLLATE some_collation_name ASC);
+
+-- valid.
+CREATE INDEX index_4
+ON test (coalesce(_id) COLLATE some_collation_name ASC);


### PR DESCRIPTION
Fixes https://github.com/cashapp/sqldelight/issues/3412

I think it is okay to not support the indexing of columns used as parameter, isn't it?