### PR TITLE
Revert moving other_expr to the top

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -201,8 +201,7 @@ drop_view_stmt ::= DROP VIEW [ IF EXISTS ] [ database_name DOT ] view_name {
   stubClass = "com.alecstrong.sql.psi.core.psi.SchemaContributorStub"
   pin = 2
 }
-expr ::= ( other_expr
-         | raise_expr
+expr ::= ( raise_expr
          | case_expr
          | exists_expr
          | multi_column_expr
@@ -225,6 +224,7 @@ expr ::= ( other_expr
          | binary_pipe_expr
          | unary_expr
          | literal_expr
+         | other_expr
          | column_expr
          | bind_expr )
 


### PR DESCRIPTION
This is the default: `other_expr ::= NULL`, so it matches the `NULL` literal which will break sqldelight because `NULL` now matches `otheer_expr` and not `literal_expr` which is checked in sqldelight so a non-null type is now null and vice versa.