### PR TITLE
Move select into into a sub rule

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -330,12 +330,15 @@ compound_select_stmt ::= [ with_clause ] select_stmt  ( compound_operator select
   ]
 }
 limiting_term ::= expr
-select_stmt ::= SELECT [ DISTINCT | ALL ] result_column ( COMMA result_column ) * [INTO bind_expr ( COMMA bind_expr ) * ] [ FROM join_clause ] [ WHERE expr ] [ GROUP BY expr ( COMMA expr ) * [ HAVING expr ] ] | VALUES values_expression ( COMMA values_expression ) * {
+select_stmt ::= SELECT [ DISTINCT | ALL ] result_column ( COMMA result_column ) * [select_into_clause] [ FROM join_clause ] [ WHERE expr ] [ GROUP BY expr ( COMMA expr ) * [ HAVING expr ] ] | VALUES values_expression ( COMMA values_expression ) * {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.SelectStmtMixin"
   implements = [
     "com.alecstrong.sql.psi.core.psi.QueryElement";
     "com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
   ]
+  pin = 1
+}
+select_into_clause ::= INTO bind_expr ( COMMA bind_expr ) * {
   pin = 1
 }
 values_expression ::= LP expr ( COMMA expr ) * RP


### PR DESCRIPTION
`statement.findChildrenOfType<SqlBindExpr>()` contains these special bindings too, so it is easier to filter it by its parent: https://github.com/cashapp/sqldelight/blob/d7b94d369a10542f3c04f44f26c50c4a4d22be90/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/BindableQuery.kt#L96