### PR TITLE
Remove useless cast

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/SqlNamedElementImpl.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/SqlNamedElementImpl.kt
@@ -1,9 +1,9 @@
 package com.alecstrong.sql.psi.core.psi
 
 import com.alecstrong.sql.psi.core.SqlParser
-import com.alecstrong.sql.psi.core.SqlParserDefinition
 import com.intellij.lang.ASTNode
 import com.intellij.lang.LanguageParserDefinitions
+import com.intellij.lang.ParserDefinition
 import com.intellij.lang.PsiBuilder
 import com.intellij.lang.PsiBuilderFactory
 import com.intellij.lang.parser.GeneratedParserUtilBase
@@ -34,7 +34,7 @@ abstract class SqlNamedElementImpl(
     // is implemented since it's inspired by that, which is documented online in IntelliJ's
     // official documentation for writing a language plugin. Good luck!
 
-    val parserDefinition = LanguageParserDefinitions.INSTANCE.forLanguage(language) as SqlParserDefinition
+    val parserDefinition: ParserDefinition = LanguageParserDefinitions.INSTANCE.forLanguage(language)
     var builder = PsiBuilderFactory.getInstance().createBuilder(
       project,
       parent.node,


### PR DESCRIPTION
It is not needed and while SqlParserDefinition is abstract, SqlDelightParserDefinition is not.

So this code does not work, because, during renaming a NamedElement, it will throw a (useless) CCE.
```kotlin
private class Db2ParserDefinition : ParserDefinition by SqlDelightParserDefinition() {
    override fun createParser(project: Project): PsiParser {
        SqlParserUtil.reset()
        SqldelightParserUtil.reset()

        val dialect = Db2Dialect()
        dialect.setup()
        SqldelightParserUtil.overrideSqlParser()

        val currentElementCreation = SqldelightParserUtil.createElement
        SqldelightParserUtil.createElement = {
            currentElementCreation(it)
        }
        return SqlParser()
    }
}
```