### PR TITLE
Add option to specify system tables and its columns

### DIFF
--- a/core/src/test/kotlin/com/alecstrong/sql/psi/core/TablesExposedTest.kt
+++ b/core/src/test/kotlin/com/alecstrong/sql/psi/core/TablesExposedTest.kt
@@ -35,6 +35,17 @@ class TablesExposedTest {
       |);
       """.trimMargin(),
       "1.s",
+      predefined = listOf(
+        PredefinedTable(
+          "predefined",
+          "1.predefined",
+          """
+      |CREATE TABLE predefined (
+      |  id TEXT NOT NULL
+      |);
+          """.trimMargin(),
+        ),
+      ),
     )
     val file = compileFile(
       """
@@ -73,6 +84,17 @@ class TablesExposedTest {
       |);
       """.trimMargin(),
       "1.s",
+      predefined = listOf(
+        PredefinedTable(
+          "predefined",
+          "1.predefined",
+          """
+      |CREATE TABLE predefined (
+      |  id TEXT NOT NULL
+      |);
+          """.trimMargin(),
+        ),
+      ),
     )
     val file = compileFile(
       """

--- a/sample-headless/src/main/kotlin/com/alecstrong/sqlite/psi/sample/headless/SampleHeadlessParser.kt
+++ b/sample-headless/src/main/kotlin/com/alecstrong/sqlite/psi/sample/headless/SampleHeadlessParser.kt
@@ -11,6 +11,8 @@ class SampleHeadlessParser {
     val environment = object : SqlCoreEnvironment(
       sourceFolders = listOf(File("sample-headless")),
       dependencies = emptyList(),
+      predefinedTables = emptyList(),
+      language = parserDefinition.getLanguage(),
     ) {
       init {
         initializeApplication {

--- a/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/CompileFile.kt
+++ b/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/CompileFile.kt
@@ -1,9 +1,10 @@
 package com.alecstrong.sql.psi.test.fixtures
 
+import com.alecstrong.sql.psi.core.PredefinedTable
 import com.alecstrong.sql.psi.core.SqlFileBase
 import java.io.File
 
-fun compileFile(text: String, fileName: String = "temp.s"): SqlFileBase {
+fun compileFile(text: String, fileName: String = "temp.s", predefined: List<PredefinedTable> = emptyList()): SqlFileBase {
   val directory = File("build/tmp").apply { mkdirs() }
   val file = File(directory, fileName).apply {
     createNewFile()
@@ -14,9 +15,11 @@ fun compileFile(text: String, fileName: String = "temp.s"): SqlFileBase {
   val parser = TestHeadlessParser()
   val environment = parser.build(
     root = directory.path,
-  ) { element, message ->
-    throw AssertionError("at ${element.textOffset} : $message")
-  }
+    annotator = { element, message ->
+      throw AssertionError("at ${element.textOffset} : $message")
+    },
+    predefinedTables = predefined,
+  )
 
   var result: SqlFileBase? = null
   environment.forSourceFiles<SqlFileBase> {

--- a/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/FixturesTest.kt
+++ b/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/FixturesTest.kt
@@ -1,5 +1,6 @@
 package com.alecstrong.sql.psi.test.fixtures
 
+import com.alecstrong.sql.psi.core.PredefinedTable
 import com.alecstrong.sql.psi.core.SqlFileBase
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
@@ -28,14 +29,20 @@ abstract class FixturesTest(val name: String, val fixtureRoot: File) {
 
     val environment = parser.build(
       root = newRoot.path,
-    ) { element, s ->
-      val documentManager = PsiDocumentManager.getInstance(element.project)
-      val name = element.containingFile.name
-      val document = documentManager.getDocument(element.containingFile)!!
-      val lineNum = document.getLineNumber(element.textOffset)
-      val offsetInLine = element.textOffset - document.getLineStartOffset(lineNum)
-      errors.add("$name line ${lineNum + 1}:$offsetInLine - $s")
-    }
+      annotator = { element, s ->
+        val documentManager = PsiDocumentManager.getInstance(element.project)
+        val name = element.containingFile.name
+        val document = documentManager.getDocument(element.containingFile)!!
+        val lineNum = document.getLineNumber(element.textOffset)
+        val offsetInLine = element.textOffset - document.getLineStartOffset(lineNum)
+        errors.add("$name line ${lineNum + 1}:$offsetInLine - $s")
+      },
+      predefinedTables = newRoot.listFiles { _, name ->
+        name.endsWith(".predefined")
+      }?.map {
+        PredefinedTable("", it.nameWithoutExtension, it.readText())
+      } ?: emptyList(),
+    )
 
     val sourceFiles = StringBuilder()
     environment.forSourceFiles<SqlFileBase> {

--- a/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/TestHeadlessParser.kt
+++ b/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/TestHeadlessParser.kt
@@ -1,5 +1,6 @@
 package com.alecstrong.sql.psi.test.fixtures
 
+import com.alecstrong.sql.psi.core.PredefinedTable
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.SqlCoreEnvironment
 import com.alecstrong.sql.psi.core.SqlFileBase
@@ -14,10 +15,12 @@ import java.io.File
 class TestHeadlessParser {
   private val parserDefinition = TestParserDefinition()
 
-  fun build(root: String, annotator: SqlAnnotationHolder): SqlCoreEnvironment {
+  fun build(root: String, annotator: SqlAnnotationHolder, predefinedTables: List<PredefinedTable>): SqlCoreEnvironment {
     val environment = object : SqlCoreEnvironment(
       sourceFolders = listOf(File(root)),
       dependencies = emptyList(),
+      predefinedTables = predefinedTables,
+      language = parserDefinition.getLanguage(),
     ) {
       init {
         initializeApplication {

--- a/test-fixtures/src/main/resources/fixtures/predefined/Dual.predefined
+++ b/test-fixtures/src/main/resources/fixtures/predefined/Dual.predefined
@@ -1,0 +1,3 @@
+CREATE TABLE dual (
+  DUMMY VARCHAR(1) NOT NULL
+);

--- a/test-fixtures/src/main/resources/fixtures/predefined/Table.s
+++ b/test-fixtures/src/main/resources/fixtures/predefined/Table.s
@@ -1,0 +1,2 @@
+SELECT *
+FROM dual;


### PR DESCRIPTION
Each database has unique system tables containing system information. At the moment sql-psi does not know about these tables so referrencing to these tables fails with `No table found with name`.

Sample: DB2 requires a `FROM` clause, so you have to use the `SYSIBM.SYSDUMMY1` for simple selects: `SELECT TIME_STAMP FROM SYSIBM.SYSDUMMY1`. 
Oracle provides a similar `dual` table.

Same use case for system catalog with PostgreSQL: https://www.postgresql.org/docs/current/catalogs.html