### PR TITLE
Add generics for forSourceFiles

### DIFF
--- a/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/CompileFile.kt
+++ b/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/CompileFile.kt
@@ -24,7 +24,7 @@ fun compileFile(text: String, fileName: String = "temp.s"): SqlFileBase {
   )
 
   var result: SqlFileBase? = null
-  environment.forSourceFiles {
+  environment.forSourceFiles<SqlFileBase> {
     if (it.name == fileName) result = it
   }
   return result!!

--- a/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/FixturesTest.kt
+++ b/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/FixturesTest.kt
@@ -1,6 +1,6 @@
 package com.alecstrong.sql.psi.test.fixtures
 
-import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.SqlFileBase
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import org.junit.Test
@@ -27,21 +27,19 @@ abstract class FixturesTest(val name: String, val fixtureRoot: File) {
     }
 
     val environment = parser.build(
-      newRoot.path,
-      object : SqlAnnotationHolder {
-        override fun createErrorAnnotation(element: PsiElement, s: String) {
-          val documentManager = PsiDocumentManager.getInstance(element.project)
-          val name = element.containingFile.name
-          val document = documentManager.getDocument(element.containingFile)!!
-          val lineNum = document.getLineNumber(element.textOffset)
-          val offsetInLine = element.textOffset - document.getLineStartOffset(lineNum)
-          errors.add("$name line ${lineNum + 1}:$offsetInLine - $s")
-        }
+      root = newRoot.path,
+      annotator = { element, s ->
+        val documentManager = PsiDocumentManager.getInstance(element.project)
+        val name = element.containingFile.name
+        val document = documentManager.getDocument(element.containingFile)!!
+        val lineNum = document.getLineNumber(element.textOffset)
+        val offsetInLine = element.textOffset - document.getLineStartOffset(lineNum)
+        errors.add("$name line ${lineNum + 1}:$offsetInLine - $s")
       },
     )
 
     val sourceFiles = StringBuilder()
-    environment.forSourceFiles {
+    environment.forSourceFiles<SqlFileBase> {
       sourceFiles.append("${it.name}:\n")
       it.printTree {
         sourceFiles.append("  ")
@@ -57,7 +55,7 @@ abstract class FixturesTest(val name: String, val fixtureRoot: File) {
       expectedFailures += expectedFailuresFile.readText().splitLines().filter { it.isNotEmpty() }
     }
 
-    environment.forSourceFiles { file ->
+    environment.forSourceFiles<SqlFileBase> { file ->
       val inlineErrors = inlineErrorRegex.findAll(file.text)
       val document = PsiDocumentManager.getInstance(file.project).getDocument(file.containingFile)!!
 


### PR DESCRIPTION
I want to switch from my copied implementation of `SqlCoreEnvironment` to the one provided by sql-psi, but I need to iterate the source files for other files too.