### PR TITLE
Revert binary incompatible change

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlCoreEnvironment.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlCoreEnvironment.kt
@@ -119,8 +119,8 @@ open class SqlCoreEnvironment(
   }
 
   fun annotate(
-    extraAnnotators: Collection<SqlCompilerAnnotator> = emptyList(),
     annotationHolder: SqlAnnotationHolder,
+    extraAnnotators: Collection<SqlCompilerAnnotator> = emptyList(),
   ) {
     val otherFailures = mutableListOf<() -> Unit>()
     val myHolder = SqlAnnotationHolder { element, s ->

--- a/sample-headless/src/main/kotlin/com/alecstrong/sqlite/psi/sample/headless/SampleHeadlessParser.kt
+++ b/sample-headless/src/main/kotlin/com/alecstrong/sqlite/psi/sample/headless/SampleHeadlessParser.kt
@@ -19,9 +19,11 @@ class SampleHeadlessParser {
         }
       }
     }
-    environment.annotate { _, message ->
-      System.err.println(message)
-    }
+    environment.annotate(
+      { _, message ->
+        System.err.println(message)
+      },
+    )
   }
 }
 


### PR DESCRIPTION
Otherwise, it is not possible to use this snapshot with sqldelight without patching sqldelight too. 
Only effects sqldelight snapshots using the unshaded dependencies.