### PR TITLE
Remove unused EOL token

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlLexer.flex
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlLexer.flex
@@ -22,7 +22,6 @@ import static com.alecstrong.sql.psi.core.psi.SqlTypes.*;
 %type IElementType
 %unicode
 
-EOL=\R
 WHITE_SPACE=\s+
 
 COMMENT=--.*


### PR DESCRIPTION
```
Warning : Macro "EOL" has been declared but never used.
```