### PR TITLE
Move system tables into SqlFileBase

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlFileBase.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlFileBase.kt
@@ -21,7 +21,7 @@ import kotlin.reflect.KClass
 abstract class SqlFileBase(
   viewProvider: FileViewProvider,
   language: Language,
-  predefinedTables: Collection<PredefinedTable>,
+  predefinedTables: Collection<PredefinedTable> = emptyList(),
 ) : PsiFileBase(viewProvider, language) {
   abstract val order: Int?
 

--- a/core/src/test/kotlin/com/alecstrong/sql/psi/core/TablesExposedTest.kt
+++ b/core/src/test/kotlin/com/alecstrong/sql/psi/core/TablesExposedTest.kt
@@ -35,17 +35,6 @@ class TablesExposedTest {
       |);
       """.trimMargin(),
       "1.s",
-      predefined = listOf(
-        PredefinedTable(
-          "predefined",
-          "1.predefined",
-          """
-      |CREATE TABLE predefined (
-      |  id TEXT NOT NULL
-      |);
-          """.trimMargin(),
-        ),
-      ),
     )
     val file = compileFile(
       """
@@ -58,6 +47,17 @@ class TablesExposedTest {
       |ALTER TABLE test3 RENAME TO test5;
       """.trimMargin(),
       "2.s",
+      predefined = listOf(
+        PredefinedTable(
+          "predefined",
+          "1.predefined",
+          """
+      |CREATE TABLE predefined (
+      |  id TEXT NOT NULL
+      |);
+          """.trimMargin(),
+        ),
+      ),
     )
 
     assertThat(file.tables(includeAll = true).map { it.tableName.text }).containsExactly(
@@ -65,6 +65,7 @@ class TablesExposedTest {
       "test2",
       "test4",
       "test5",
+      "predefined",
     )
   }
 

--- a/sample-core/src/main/kotlin/com/alecstrong/sql/psi/sample/core/SampleFile.kt
+++ b/sample-core/src/main/kotlin/com/alecstrong/sql/psi/sample/core/SampleFile.kt
@@ -3,7 +3,7 @@ package com.alecstrong.sql.psi.sample.core
 import com.alecstrong.sql.psi.core.SqlFileBase
 import com.intellij.psi.FileViewProvider
 
-class SampleFile(viewProvider: FileViewProvider) : SqlFileBase(viewProvider, SampleLanguage) {
+class SampleFile(viewProvider: FileViewProvider) : SqlFileBase(viewProvider, SampleLanguage, predefinedTables = emptyList()) {
   override val order = name.substringBefore(".${fileType.defaultExtension}").let { name ->
     if (name.all { it in '0'..'9' }) name.toInt()
     else null

--- a/sample-headless/src/main/kotlin/com/alecstrong/sqlite/psi/sample/headless/SampleHeadlessParser.kt
+++ b/sample-headless/src/main/kotlin/com/alecstrong/sqlite/psi/sample/headless/SampleHeadlessParser.kt
@@ -11,8 +11,6 @@ class SampleHeadlessParser {
     val environment = object : SqlCoreEnvironment(
       sourceFolders = listOf(File("sample-headless")),
       dependencies = emptyList(),
-      predefinedTables = emptyList(),
-      language = parserDefinition.getLanguage(),
     ) {
       init {
         initializeApplication {

--- a/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/CompileFile.kt
+++ b/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/CompileFile.kt
@@ -12,8 +12,7 @@ fun compileFile(text: String, fileName: String = "temp.s", predefined: List<Pred
   }
   file.writeText(text)
 
-  val parser = TestHeadlessParser()
-  val environment = parser.build(
+  val environment = TestHeadlessParser.build(
     root = directory.path,
     annotator = { element, message ->
       throw AssertionError("at ${element.textOffset} : $message")

--- a/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/FixturesTest.kt
+++ b/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/FixturesTest.kt
@@ -22,7 +22,6 @@ abstract class FixturesTest(
   @Test fun execute() {
     setupDialect()
 
-    val parser = TestHeadlessParser()
     val errors = ArrayList<String>()
 
     val newRoot = File("build/fixtureCopies/${fixtureRoot.name}Copy")
@@ -31,7 +30,7 @@ abstract class FixturesTest(
       newRoot.replaceKeywords()
     }
 
-    val environment = parser.build(
+    val environment = TestHeadlessParser.build(
       root = newRoot.path,
       annotator = { element, s ->
         val documentManager = PsiDocumentManager.getInstance(element.project)
@@ -92,9 +91,11 @@ abstract class FixturesTest(
       missingList.isNotEmpty() && extrasList.isNotEmpty() -> {
         throw AssertionError("Test failed because the compile output is missing $missingStr and unexpectedly has $extrasStr. $assertionMsgEnd")
       }
+
       missingList.isNotEmpty() -> {
         throw AssertionError("Test failed because the compile output is missing $missingStr. $assertionMsgEnd")
       }
+
       extrasList.isNotEmpty() -> {
         throw AssertionError("Test failed because the compile output unexpectedly has $extrasStr. $assertionMsgEnd")
       }

--- a/test-fixtures/src/main/resources/fixtures/predefined/Select.s
+++ b/test-fixtures/src/main/resources/fixtures/predefined/Select.s
@@ -1,0 +1,2 @@
+SELECT *
+FROM dual;


### PR DESCRIPTION
Draft, because I don't understand, why this doesn't work.
If I execute the test with `predefined` folder only, the test passes. If I execute all fixture folders, it fails.
But I don't know why. I thought we create a new environment for each test execution. Or is there any kind of cache?