### PR TITLE
remove literal expression error

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/LiteralValueMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/LiteralValueMixin.kt
@@ -1,38 +1,10 @@
 package com.alecstrong.sql.psi.core.psi.mixins
 
-import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
-import com.alecstrong.sql.psi.core.psi.SqlCreateTableStmt
-import com.alecstrong.sql.psi.core.psi.SqlInsertStmt
 import com.alecstrong.sql.psi.core.psi.SqlLiteralValue
-import com.alecstrong.sql.psi.core.psi.SqlSetterExpression
-import com.alecstrong.sql.psi.core.psi.SqlTypes
-import com.alecstrong.sql.psi.core.psi.SqlValuesExpression
 import com.intellij.lang.ASTNode
-import com.intellij.psi.tree.TokenSet
-import com.intellij.psi.util.PsiTreeUtil
 
 internal abstract class LiteralValueMixin(
   node: ASTNode,
 ) : SqlCompositeElementImpl(node),
-  SqlLiteralValue {
-  override fun annotate(annotationHolder: SqlAnnotationHolder) {
-    if (node.findChildByType(setterOnlyLiterals) != null) {
-      val values = PsiTreeUtil.getParentOfType(this, SqlValuesExpression::class.java)
-
-      if (values != null && values.parent is SqlInsertStmt) return
-      if (PsiTreeUtil.getParentOfType(this, SqlSetterExpression::class.java) != null) return
-      if (PsiTreeUtil.getParentOfType(this, SqlCreateTableStmt::class.java) != null) return
-
-      annotationHolder.createErrorAnnotation(this, "Cannot use time literal in expression")
-    }
-  }
-
-  companion object {
-    private val setterOnlyLiterals = TokenSet.create(
-      SqlTypes.CURRENT_DATE,
-      SqlTypes.CURRENT_TIME,
-      SqlTypes.CURRENT_TIMESTAMP,
-    )
-  }
-}
+  SqlLiteralValue

--- a/test-fixtures/src/main/resources/fixtures/timestamp-literals/Test.s
+++ b/test-fixtures/src/main/resources/fixtures/timestamp-literals/Test.s
@@ -22,4 +22,4 @@ UPDATE test
 SET date1 = CURRENT_TIMESTAMP,
     date2 = CURRENT_TIME,
     date3 = CURRENT_TIMESTAMP
-WHERE date1 > CURRENT_TIME; -- Fails because it is an expression.
+WHERE date1 > CURRENT_TIME;

--- a/test-fixtures/src/main/resources/fixtures/timestamp-literals/failure.txt
+++ b/test-fixtures/src/main/resources/fixtures/timestamp-literals/failure.txt
@@ -1,1 +1,0 @@
-Test.s line 25:14 - Cannot use time literal in expression


### PR DESCRIPTION
closes #514

Removing this restriction allows literals like date/time to be used in criteria queries.

The following is valid Sql that should be allowed 💯 

``` sql
UPDATE test
SET date1 = CURRENT_TIMESTAMP,
    date2 = CURRENT_TIME,
    date3 = CURRENT_TIMESTAMP
WHERE date1 > CURRENT_TIME;
```

⚠️ I have tested this with SqlDelight using the publishLocalToMaven with the current snapshot. 📷 
However, SqlDelight is using sql-psi `0.4.3` and this current `0.5.0-Snapshot` is not compatible (as expected semantically) with SqlDelight.  e.g https://github.com/cashapp/sqldelight/blob/master/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/SqlDelightEnvironment.kt#L75 and https://github.com/AlecStrong/sql-psi/blob/master/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlCoreEnvironment.kt#L68

Either changes should be made on top of `0.4.3` or wait for `0.5.0` to be integrated into SqlDelight ⚔️ 

Found this `0.5.0` release to be integrated with SqlDelight 🏒 🥅  and appears to fix the breaking differences
https://github.com/cashapp/sqldelight/pull/4283#event-9548398516 - so can wait for that to be merged 🧜 