### PR TITLE
Don't use NULL in extension rule

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -44,6 +44,8 @@
     LOCK='LOCK'
     USE='USE'
 
+    FAKE_EXTENSION='___'
+
     space='regexp:\s+'
     comment='regexp:--.*'
     javadoc='regexp:/\*\*([^*]|\*+[^/*])*\*/'
@@ -58,9 +60,9 @@ stmt_list ::= ( stmt SEMI ) * {
   mixin="com.alecstrong.sql.psi.core.psi.mixins.SqlStmtListMixin"
   pin(".*")=1
 }
-stmt ::= [ EXPLAIN [ QUERY PLAN ] ] ( alter_table_stmt | analyze_stmt | attach_stmt | begin_stmt | commit_stmt | create_index_stmt | create_table_stmt | create_trigger_stmt | create_view_stmt |
+stmt ::= [ EXPLAIN [ QUERY PLAN ] ] ( extension_stmt | alter_table_stmt | analyze_stmt | attach_stmt | begin_stmt | commit_stmt | create_index_stmt | create_table_stmt | create_trigger_stmt | create_view_stmt |
                                           create_virtual_table_stmt | delete_stmt_limited | detach_stmt | drop_index_stmt | drop_table_stmt | drop_trigger_stmt | drop_view_stmt | insert_stmt |
-                                          pragma_stmt | reindex_stmt | release_stmt | rollback_stmt | savepoint_stmt | compound_select_stmt | update_stmt_limited | vacuum_stmt | extension_stmt
+                                          pragma_stmt | reindex_stmt | release_stmt | rollback_stmt | savepoint_stmt | compound_select_stmt | update_stmt_limited | vacuum_stmt
                                         ) {
   recoverWhile=sql_stmt_recovery
   pin = 2
@@ -230,8 +232,8 @@ expr ::= ( other_expr
          | bind_expr )
 
 other_expr ::= extension_expr
-extension_expr ::= NULL
-extension_stmt ::= NULL
+extension_expr ::= FAKE_EXTENSION
+extension_stmt ::= FAKE_EXTENSION
 multi_column_expr ::= values_expression ( LT | LTE | GT | GTE ) values_expression {
   pin = 2
 }

--- a/core/src/test/kotlin/com/alecstrong/sql/psi/core/NullabilityTest.kt
+++ b/core/src/test/kotlin/com/alecstrong/sql/psi/core/NullabilityTest.kt
@@ -1,0 +1,104 @@
+package com.alecstrong.sql.psi.core
+
+import com.alecstrong.sql.psi.test.fixtures.compileFile
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class NullabilityTest {
+  @Test
+  fun outerJoin() {
+    val file = compileFile(
+      """
+      |CREATE TABLE car (
+      |  _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+      |  id TEXT NOT NULL,
+      |  brand TEXT NOT NULL
+      |);
+      |
+      |CREATE TABLE owner (
+      |  _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+      |  name TEXT NOT NULL,
+      |  carId TEXT
+      |);
+      |
+      |SELECT *
+      |FROM (SELECT owner.name, car.brand AS carBrand, car.rowid AS rowid
+      |      FROM owner
+      |      LEFT OUTER JOIN car ON owner.carId = car.id)
+      |WHERE carBrand = ?;
+      """.trimMargin(),
+    )
+
+    val select = file.sqlStmtList!!.stmtList.mapNotNull { it.compoundSelectStmt }.single()
+    val projection = select.queryExposed().flatMap { it.columns }
+
+    assertThat(projection[0].nullable).isNull()
+    assertThat(projection[1].nullable).isTrue()
+    assertThat(projection[2].nullable).isTrue()
+  }
+
+  @Test
+  fun leftJoinGroupBy() {
+    val file = compileFile(
+      """
+      |CREATE TABLE target (
+      |  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+      |  coacheeId INTEGER NOT NULL,
+      |  name TEXT NOT NULL
+      |);
+      |
+      |CREATE TABLE challengeTarget (
+      |  targetId INTEGER NOT NULL,
+      |  challengeId INTEGER NOT NULL
+      |);
+      |
+      |CREATE TABLE challenge (
+      |  id INTEGER NOT NULL,
+      |  cancelledAt INTEGER,
+      |  emoji TEXT
+      |);
+      |
+      |SELECT target.id AS id, target.name AS name, challenge.emoji
+      |  FROM target
+      |  LEFT JOIN challengeTarget
+      |    ON challengeTarget.targetId = target.id
+      |  LEFT JOIN challenge
+      |    ON challengeTarget.challengeId = challenge.id AND challenge.cancelledAt IS NULL
+      |  WHERE target.coacheeId = ?
+      |  GROUP BY 1
+      |  ORDER BY target.name COLLATE NOCASE ASC
+      |;
+      """.trimMargin(),
+    )
+
+    val select = file.sqlStmtList!!.stmtList.mapNotNull { it.compoundSelectStmt }.single()
+    val projection = select.queryExposed().flatMap { it.columns }
+
+    assertThat(projection[0].nullable).isNull()
+    assertThat(projection[1].nullable).isNull()
+    assertThat(projection[2].nullable).isTrue()
+  }
+
+  @Test
+  fun checkNotNull() {
+    val file = compileFile(
+      """
+      |CREATE TABLE target (
+      |  name TEXT,
+      |  thing TEXT
+      |);
+      |
+      |SELECT name, name AS poop, thing AS poop2
+      |FROM target
+      |WHERE name IS NOT NULL AND thing IS NOT NULL;
+      """.trimMargin(),
+    )
+
+    val select = file.sqlStmtList!!.stmtList.mapNotNull { it.compoundSelectStmt }.single()
+    val projection = select.queryExposed().flatMap { it.columns }
+
+    assertThat(projection[0].nullable).isFalse()
+    assertThat(projection[1].nullable).isFalse()
+    assertThat(projection[2].nullable).isFalse()
+  }
+}


### PR DESCRIPTION
Currently, we reuse the `NULL` literal in the extension expr/stmt to have a valid rule, but this results into failings if the extension expr is moved to the top, before literal expr. While we could simply move literal expr to the top, I choose another solution to create a fake token to fill the rule.

I also moved the NullabilityTest to the sql-psi project because it does not require any sqlite dialect.