### PR TITLE
Fix invalid column type

### DIFF
--- a/test-fixtures/src/main/resources/fixtures/parentheses/Test.s
+++ b/test-fixtures/src/main/resources/fixtures/parentheses/Test.s
@@ -1,6 +1,6 @@
 CREATE TABLE Item(
-    gross INT NOT NULL,
-    tare INT NOT NULL
+    gross INTEGER NOT NULL,
+    tare INTEGER NOT NULL
 );
 
 -- This expr should match parenExpr and not multi column expr.


### PR DESCRIPTION
`sql-psi` does not have a type checker, but sqlite does only support `INTEGER`. Currently, we need to add a replacement rule in the sqlite dialect tests.